### PR TITLE
feat: add user asset import pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,9 @@ Thumbs.db
 
 # Phaser 原型生成的构建素材
 assets/build/**
+assets/user_imports/**
+!assets/user_imports/README.md
+!assets/user_imports/user_manifest.json
 frontend/phaser/assets/build/**
 __pycache__/
 .venv/

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,17 @@ map:
 # 启动静态服务器预览 Phaser 像素地图原型
 web-run:
 	python -m http.server -d frontend/phaser 8080
+
+# 将用户素材导入并标准化到 assets/build/**，自动更新映射
+user-import:
+	python scripts/import_user_assets.py
+
+# 校验用户素材目录与清单配置的匹配情况
+user-verify:
+	python scripts/verify_user_assets.py
+
+# 一键导入、校验并开启前端预览服务器
+user-preview:
+	python scripts/import_user_assets.py && \
+	python scripts/verify_user_assets.py && \
+	python -m http.server -d frontend/phaser 8080

--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ python -m http.server 8000
 - `assets/mapping/tileset_binding.json` 记录了地形名称到索引的映射，可在前端或后端逻辑中复用。
 - 下一步规划：将 `frontend/phaser/maps/demo_map.json` 替换为后端 `/world/chunk` 接口生成的真实数据，并把占位玩家动画替换成更精细的多帧角色图。
 
+### 用户素材导入指南
+
+- 目录结构：在 `assets/user_imports/` 下按 `tiles/`、`characters/`、`maps/` 分类放置素材，清单文件为 `user_manifest.json`（示例已包含中文注释）。
+- 命名与尺寸：默认 `tile_size=32`；图集模式放 `tiles/tilesheet.png`，散瓦片模式放 `tiles/*.png`；玩家雪碧图默认横向 4 帧 `32×32`，可通过 manifest 修改帧数/帧率。
+- 一键导入：运行 `make user-import` 将素材复制/打包到 `assets/build/**` 并更新 `assets/mapping/tileset_binding.json`；`make user-verify` 校验尺寸与文件完整性；`make user-preview` 完成导入、校验并启动 `http://localhost:8080/` 预览。
+- 加载优先级：Phaser 前端与后端接口优先读取 `assets/build/**` 中的用户素材；若目录为空则自动回退到既有生成/占位资源，并在缺失时提示运行导入脚本。
+- 常见问题：若尺寸不整除会被脚本拒绝（或在 `--force` 下警告缩放）；散瓦片模式按文件名字典序拼合；Tiled 地图需保持 `firstgid=1`；透明像素需启用 alpha 通道。
+- 许可证：务必确认导入素材的版权与授权（推荐 CC0/CC-BY/CC-BY-SA/商业许可），并在 `assets/licenses/ASSETS_LICENSES.md` 中登记来源与作者，确保发布时合法。
+
 ---
 
 ## 调试热键（建议实现）

--- a/assets/user_imports/README.md
+++ b/assets/user_imports/README.md
@@ -1,0 +1,8 @@
+# 用户素材放置说明
+
+- `tiles/`：放置自定义地形图集或散瓦片。
+- `characters/`：放置角色雪碧图或拆分帧。
+- `maps/`：可选放置 Tiled 导出的 TMX/JSON 地图。
+- `user_manifest.json`：可选配置文件，可覆盖默认尺寸与绑定。
+
+将外部素材放入上述目录后运行 `make user-import` 完成标准化，再运行 `make user-verify` 校验。

--- a/assets/user_imports/user_manifest.json
+++ b/assets/user_imports/user_manifest.json
@@ -1,0 +1,48 @@
+{
+  "_comment": "用户素材导入配置示例，可根据自身素材调整参数。",
+  "tile_size": 32,
+  "tiles": {
+    "_comment_mode": "mode=atlas 表示使用单张图集；mode=loose 表示散瓦片；mode=auto 自动判断。",
+    "mode": "auto",
+    "atlas": "tilesheet.png",
+    "loose_glob": "*.png",
+    "bindings": {
+      "_comment_GRASS": "草地，建议编号0。",
+      "GRASS": 0,
+      "_comment_ROAD": "道路，建议编号1。",
+      "ROAD": 1,
+      "_comment_TILE_FLOOR": "瓷砖地面。",
+      "TILE_FLOOR": 2,
+      "_comment_WATER": "浅水区域。",
+      "WATER": 3,
+      "_comment_LAKE": "湖泊水面。",
+      "LAKE": 4,
+      "_comment_WALL": "墙体或高不可跨越障碍。",
+      "WALL": 5,
+      "_comment_TREE": "树木。",
+      "TREE": 6,
+      "_comment_HOUSE": "房屋或建筑。",
+      "HOUSE": 7,
+      "_comment_ROCK": "岩石或巨石。",
+      "ROCK": 8,
+      "_comment_LAVA": "岩浆或危险地块。",
+      "LAVA": 9
+    }
+  },
+  "characters": {
+    "player": {
+      "_comment_mode": "mode=atlas 表示使用横向拼接的雪碧图。",
+      "mode": "atlas",
+      "file": "player.png",
+      "frame_width": 32,
+      "frame_height": 32,
+      "frames": 4,
+      "fps": 8
+    }
+  },
+  "maps": {
+    "_comment_use_user_map": "若为 true 则使用用户自定义地图。",
+    "use_user_map": false,
+    "file": "demo_map.json"
+  }
+}

--- a/frontend/phaser/main.js
+++ b/frontend/phaser/main.js
@@ -1,161 +1,324 @@
-// 全局常量：瓦片尺寸设定为32像素。
-const TILE_SIZE = 32; // 设定瓦片尺寸
-// 全局常量：按照脚本生成顺序定义地形索引映射。
-const TILE_INDEX = { // 定义名称到索引的映射
-  GRASS: 0, // 草地索引
-  ROAD: 1, // 道路索引
-  TILE_FLOOR: 2, // 瓷砖地板索引
-  WATER: 3, // 水面索引
-  LAKE: 4, // 湖泊索引
-  WALL: 5, // 墙体索引
-  TREE: 6, // 树木索引
-  HOUSE: 7, // 房屋索引
-  ROCK: 8, // 岩石索引
-  LAVA: 9 // 岩浆索引
-}; // 映射定义结束
-// 不可通行瓦片集合（转换为Tiled使用的gid值）。
-const BLOCKED_GIDS = [4, 5, 6, 7, 8, 9, 10]; // 需阻挡的瓦片编号（索引+1）
-// 计算玩家移动速度常量。
-const PLAYER_SPEED = 140; // 玩家基础速度
+// 定义在地形碰撞中需要阻挡的地形名称列表。
+const BLOCKED_TILE_NAMES = [
+  "WATER", // 水面不可通行
+  "LAKE", // 湖泊不可通行
+  "WALL", // 墙体不可通行
+  "TREE", // 树木不可通行
+  "HOUSE", // 房屋不可通行
+  "ROCK", // 岩石不可通行
+  "LAVA" // 岩浆不可通行
+]; // 数组结束
 
-// 工具函数：向根节点写入消息提示用户生成资源。
-function showAssetMissingMessage(message) { // 定义缺失资源提示函数
-  const root = document.getElementById("app-root"); // 获取主容器
+// 定义资源加载优先级，用户构建目录优先，随后回退到既有生成或占位资源。
+const ASSET_PRIORITIES = {
+  tiles: [
+    "assets/build/tiles/tilesheet.png", // 用户导入后的图集
+    "assets/generated/tiles/tilesheet.png" // 旧版生成图集（若存在）
+  ], // 瓦片资源优先级结束
+  characters: {
+    player: [
+      "assets/build/characters/player.png", // 用户导入玩家雪碧图
+      "assets/generated/characters/player.png" // 旧版生成雪碧图（若存在）
+    ], // 玩家雪碧图优先级结束
+    anim: [
+      "assets/build/characters/player.anim.json", // 用户导入玩家动画配置
+      "assets/generated/characters/player.anim.json" // 旧版生成动画配置（若存在）
+    ] // 玩家动画配置优先级结束
+  }, // 角色资源部分结束
+  maps: [
+    "maps/user_map.json", // 用户自定义地图
+    "maps/demo_map.json" // 默认演示地图
+  ], // 地图资源优先级结束
+  mapping: [
+    "assets/mapping/tileset_binding.json" // 瓦片绑定配置
+  ] // 绑定配置列表结束
+}; // 常量定义结束
+
+// 将优先级常量暴露到全局，便于测试脚本读取验证。
+if (typeof window !== "undefined") { // 检查处于浏览器环境
+  window.MINIWORLD_ASSET_PRIORITIES = ASSET_PRIORITIES; // 挂载到全局变量
+} // 条件结束
+
+// 定义全局运行时配置对象的占位，稍后在引导阶段填充。
+let runtimeConfig = null; // 初始化运行时配置
+
+// 将错误提示写入页面，提醒用户缺失资源或环境。
+function showAssetMissingMessage(message) { // 定义提示函数
+  const root = document.getElementById("app-root"); // 获取根容器
   if (root) { // 确认容器存在
-    root.innerHTML = `<p>${message}</p>`; // 替换容器内容为提示文本
+    root.innerHTML = `<p>${message}</p>`; // 写入提示文本
   } // 条件结束
 } // 函数结束
 
-// 自定义场景类，负责加载资源与处理交互。
+// 检测指定资源路径是否存在，优先使用 HEAD 请求以减少流量。
+async function checkAssetAvailability(path) { // 定义资源存在性检测函数
+  try { // 捕获网络错误
+    const response = await fetch(path, { method: "HEAD" }); // 使用HEAD请求探测
+    if (response.ok) { // 如果响应成功
+      return true; // 返回存在
+    } // 条件结束
+  } catch (error) { // 捕获异常
+    console.warn("检查资源时出现异常", path, error); // 打印警告
+  } // 捕获结束
+  try { // 再次尝试使用GET以兼容不支持HEAD的环境
+    const response = await fetch(path, { method: "GET" }); // 使用GET请求探测
+    return response.ok; // 返回是否成功
+  } catch (error) { // 捕获异常
+    console.warn("使用GET检查资源失败", path, error); // 输出警告
+    return false; // 返回不存在
+  } // 捕获结束
+} // 函数结束
+
+// 在给定的路径优先级列表中寻找第一个存在的资源。
+async function resolveAssetPath(paths) { // 定义路径解析函数
+  for (const path of paths) { // 遍历候选路径
+    // eslint-disable-next-line no-await-in-loop
+    const available = await checkAssetAvailability(path); // 逐个检查资源
+    if (available) { // 如果存在
+      return path; // 返回该路径
+    } // 条件结束
+  } // 循环结束
+  return null; // 若都不存在则返回空
+} // 函数结束
+
+// 依次尝试加载 JSON 文件，成功后返回解析结果与路径。
+async function loadJsonFromPriority(paths) { // 定义JSON加载函数
+  for (const path of paths) { // 遍历候选
+    try { // 捕获请求异常
+      // eslint-disable-next-line no-await-in-loop
+      const response = await fetch(path); // 直接获取JSON
+      if (response.ok) { // 检查状态
+        // eslint-disable-next-line no-await-in-loop
+        const data = await response.json(); // 解析JSON
+        return { data, path }; // 返回数据与路径
+      } // 条件结束
+    } catch (error) { // 捕获异常
+      console.warn("加载JSON失败", path, error); // 输出警告
+    } // 捕获结束
+  } // 循环结束
+  return { data: null, path: null }; // 若都失败返回空结果
+} // 函数结束
+
+// 根据绑定数据计算不可通行的瓦片gid列表。
+function computeBlockedGids(bindings) { // 定义碰撞gid计算函数
+  const gids = []; // 初始化gid数组
+  BLOCKED_TILE_NAMES.forEach((name) => { // 遍历不可通行名称
+    if (Object.prototype.hasOwnProperty.call(bindings, name)) { // 若绑定存在
+      const index = bindings[name]; // 读取索引
+      gids.push(index + 1); // 转换为Tiled使用的gid
+    } // 条件结束
+  }); // 遍历结束
+  if (gids.length === 0) { // 若未找到任何阻挡瓦片
+    console.warn("未找到阻挡瓦片配置，默认保持空列表"); // 输出警告
+  } // 条件结束
+  return gids; // 返回gid列表
+} // 函数结束
+
+// 基于绑定数据查找指定名称对应的gid。
+function gidForName(bindings, name) { // 定义gid查询函数
+  if (!Object.prototype.hasOwnProperty.call(bindings, name)) { // 若名称不存在
+    return null; // 返回空
+  } // 条件结束
+  return bindings[name] + 1; // 返回gid值
+} // 函数结束
+
+// 自定义场景类，使用运行时配置加载资源与创建地图。
 class MiniWorldScene extends Phaser.Scene { // 定义MiniWorldScene类
   constructor() { // 构造函数
-    super({ key: "MiniWorldScene" }); // 调用父类构造并传递键名
+    super({ key: "MiniWorldScene" }); // 调用父类构造
     this.failedAssets = []; // 初始化加载失败列表
     this.player = null; // 初始化玩家引用
-    this.cursors = null; // 初始化方向键引用
+    this.cursors = null; // 初始化输入引用
     this.resetKey = null; // 初始化重置键引用
-    this.spawnPoint = { x: TILE_SIZE * 2, y: TILE_SIZE * 2 }; // 初始化出生点
-    this.tileLayer = null; // 初始化瓦片层引用
+    this.spawnPoint = { x: 0, y: 0 }; // 初始化出生点
+    this.tileLayer = null; // 初始化瓦片层
   } // 构造函数结束
 
   preload() { // Phaser预加载阶段
+    if (!runtimeConfig) { // 如果运行时配置缺失
+      showAssetMissingMessage("运行时配置缺失，请先执行素材导入脚本。"); // 提示用户
+      return; // 中断
+    } // 条件结束
     this.failedAssets = []; // 清空失败列表
-    this.load.on("loaderror", (file) => { // 监听加载错误事件
-      this.failedAssets.push(file.src || file.key); // 将失败资源记录到数组
+    this.load.on("loaderror", (file) => { // 监听加载错误
+      this.failedAssets.push(file.src || file.key); // 记录失败资源
     }); // 事件绑定结束
-    this.load.tilemapTiledJSON("demoMap", "maps/demo_map.json"); // 加载Tiled地图JSON
-    this.load.image("worldTiles", "assets/build/tiles/tilesheet.png"); // 加载瓦片图集
-    this.load.spritesheet("playerSprite", "assets/build/characters/player.png", { frameWidth: TILE_SIZE, frameHeight: TILE_SIZE }); // 加载玩家精灵
+    this.load.tilemapTiledJSON("activeMap", runtimeConfig.assetPaths.map); // 加载地图JSON
+    this.load.image("worldTiles", runtimeConfig.assetPaths.tiles); // 加载瓦片图集
+    this.load.spritesheet(
+      "playerSprite", // 资源键名
+      runtimeConfig.assetPaths.player, // 雪碧图路径
+      {
+        frameWidth: runtimeConfig.playerAnim.frame_width, // 帧宽
+        frameHeight: runtimeConfig.playerAnim.frame_height // 帧高
+      }
+    ); // 注册雪碧图
   } // preload结束
 
   create() { // Phaser创建阶段
-    if (this.failedAssets.length > 0 || !this.cache.tilemap.exists("demoMap") || !this.textures.exists("worldTiles")) { // 判断资源是否缺失
-      showAssetMissingMessage("请先运行 make assets 生成素材与地图。"); // 输出提示
-      return; // 中断创建流程
+    if (
+      !runtimeConfig || // 缺少配置
+      this.failedAssets.length > 0 || // 有加载失败
+      !this.cache.tilemap.exists("activeMap") || // 地图未加载
+      !this.textures.exists("worldTiles") || // 图集未加载
+      !this.textures.exists("playerSprite") // 雪碧图未加载
+    ) { // 条件组合
+      showAssetMissingMessage("资源加载失败，请确认已执行 make user-import 或 make assets。"); // 提示用户
+      return; // 中断
     } // 条件结束
-    const map = this.make.tilemap({ key: "demoMap" }); // 根据缓存创建地图对象
-    const tileset = map.addTilesetImage("world_tiles", "worldTiles", TILE_SIZE, TILE_SIZE, 0, 0, 1); // 将瓦片集与纹理绑定
+    const map = this.make.tilemap({ key: "activeMap" }); // 创建地图对象
+    const tileset = map.addTilesetImage(
+      "world_tiles", // tileset名称
+      "worldTiles", // 纹理键名
+      runtimeConfig.tileSize, // 瓦片宽
+      runtimeConfig.tileSize, // 瓦片高
+      0, // 边距
+      0, // 间距
+      1 // firstgid
+    ); // tileset绑定结束
     this.tileLayer = map.createLayer("Ground", tileset, 0, 0); // 创建地面层
-    this.tileLayer.setOrigin(0, 0); // 设置瓦片层原点到左上角
-    this.tileLayer.setCollision(BLOCKED_GIDS); // 设置不可通行瓦片碰撞
-    const spawnTile = this.findRoadTile(); // 查找道路出生点
-    if (spawnTile) { // 如果找到道路瓦片
-      this.spawnPoint = { // 更新出生点坐标
-        x: spawnTile.getCenterX(), // 设置X坐标
-        y: spawnTile.getCenterY() // 设置Y坐标
-      }; // 对象结束
-    } // 条件结束
-    this.player = this.physics.add.sprite(this.spawnPoint.x, this.spawnPoint.y, "playerSprite", 0); // 创建玩家精灵
-    this.player.setCollideWorldBounds(true); // 限制玩家在地图内
-    this.player.body.setSize(TILE_SIZE * 0.6, TILE_SIZE * 0.8); // 调整碰撞箱尺寸
-    this.player.body.setOffset(TILE_SIZE * 0.2, TILE_SIZE * 0.2); // 调整碰撞箱偏移
-    this.anims.create({ // 创建玩家走路动画
-      key: "walk", // 动画键名
-      frames: this.anims.generateFrameNumbers("playerSprite", { start: 0, end: 3 }), // 指定帧范围
-      frameRate: 8, // 帧率
+    this.tileLayer.setOrigin(0, 0); // 设置原点
+    this.tileLayer.setCollision(runtimeConfig.blockedGids); // 配置碰撞gid
+    const roadGid = gidForName(runtimeConfig.bindings, "ROAD"); // 获取道路gid
+    if (roadGid !== null) { // 如果存在道路
+      const tile = this.tileLayer.findTile((t) => t.index === roadGid); // 查找道路瓦片
+      if (tile) { // 若找到
+        this.spawnPoint = { x: tile.getCenterX(), y: tile.getCenterY() }; // 设置出生点
+      } // 条件结束
+    } // 道路判断结束
+    this.player = this.physics.add.sprite(
+      this.spawnPoint.x, // X坐标
+      this.spawnPoint.y, // Y坐标
+      "playerSprite", // 纹理键
+      0 // 初始帧
+    ); // 创建玩家精灵
+    this.player.setCollideWorldBounds(true); // 限制出界
+    this.player.body.setSize(
+      runtimeConfig.tileSize * 0.6, // 碰撞箱宽
+      runtimeConfig.tileSize * 0.8 // 碰撞箱高
+    ); // 设置碰撞箱尺寸
+    this.player.body.setOffset(
+      runtimeConfig.tileSize * 0.2, // 偏移X
+      runtimeConfig.tileSize * 0.2 // 偏移Y
+    ); // 设置碰撞箱偏移
+    this.anims.create({ // 创建走路动画
+      key: "walk", // 动画键
+      frames: this.anims.generateFrameNumbers("playerSprite", { start: 0, end: runtimeConfig.playerAnim.frames - 1 }), // 生成帧
+      frameRate: runtimeConfig.playerAnim.fps, // 帧率
       repeat: -1 // 循环播放
     }); // 动画定义结束
-    this.physics.add.collider(this.player, this.tileLayer); // 添加玩家与瓦片层碰撞
+    this.physics.add.collider(this.player, this.tileLayer); // 玩家与地面碰撞
     this.cursors = this.input.keyboard.createCursorKeys(); // 创建方向键输入
     this.resetKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.R); // 注册重置键
-    this.cameras.main.startFollow(this.player); // 相机跟随玩家
-    this.cameras.main.setBounds(0, 0, map.widthInPixels, map.heightInPixels); // 限制相机边界
-    this.physics.world.setBounds(0, 0, map.widthInPixels, map.heightInPixels); // 设置物理世界边界
+    this.cameras.main.startFollow(this.player); // 相机跟随
+    this.cameras.main.setBounds(0, 0, map.widthInPixels, map.heightInPixels); // 设置相机边界
+    this.physics.world.setBounds(0, 0, map.widthInPixels, map.heightInPixels); // 设置物理边界
   } // create结束
 
   update() { // 游戏逐帧更新
-    if (!this.player || !this.cursors) { // 如果玩家或输入未准备好
-      return; // 提前返回
+    if (!this.player || !this.cursors) { // 若玩家或输入不存在
+      return; // 直接返回
     } // 条件结束
     let velocityX = 0; // 初始化水平速度
     let velocityY = 0; // 初始化垂直速度
     if (this.cursors.left.isDown) { // 按下左键
-      velocityX -= 1; // 速度左移
+      velocityX -= 1; // 向左移动
     } // 条件结束
     if (this.cursors.right.isDown) { // 按下右键
-      velocityX += 1; // 速度右移
+      velocityX += 1; // 向右移动
     } // 条件结束
     if (this.cursors.up.isDown) { // 按下上键
-      velocityY -= 1; // 速度上移
+      velocityY -= 1; // 向上移动
     } // 条件结束
     if (this.cursors.down.isDown) { // 按下下键
-      velocityY += 1; // 速度下移
+      velocityY += 1; // 向下移动
     } // 条件结束
-    if (velocityX !== 0 && velocityY !== 0) { // 处理对角移动
-      const factor = Math.SQRT1_2; // 计算对角归一化因子
+    if (velocityX !== 0 && velocityY !== 0) { // 对角移动情况
+      const factor = Math.SQRT1_2; // 计算归一化因子
       velocityX *= factor; // 调整水平速度
       velocityY *= factor; // 调整垂直速度
     } // 条件结束
-    this.player.setVelocity(velocityX * PLAYER_SPEED, velocityY * PLAYER_SPEED); // 应用速度到玩家
-    if (velocityX !== 0 || velocityY !== 0) { // 若玩家在移动
-      this.player.anims.play("walk", true); // 播放走路动画
-    } else { // 否则保持静止
+    const speed = runtimeConfig.playerSpeed; // 读取速度配置
+    this.player.setVelocity(velocityX * speed, velocityY * speed); // 应用速度
+    if (velocityX !== 0 || velocityY !== 0) { // 若正在移动
+      this.player.anims.play("walk", true); // 播放动画
+    } else { // 否则
       this.player.anims.stop(); // 停止动画
-      this.player.setFrame(0); // 重置为第一帧
+      this.player.setFrame(0); // 重置帧
     } // 条件结束
-    if (Phaser.Input.Keyboard.JustDown(this.resetKey)) { // 检测重置按键
-      this.resetPlayerPosition(); // 调用重置函数
+    if (Phaser.Input.Keyboard.JustDown(this.resetKey)) { // 检测重置键
+      this.resetPlayerPosition(); // 调用重置
     } // 条件结束
   } // update结束
 
-  resetPlayerPosition() { // 定义重置玩家位置的函数
-    if (!this.player) { // 如果玩家不存在
-      return; // 不执行重置
+  resetPlayerPosition() { // 定义重置函数
+    if (!this.player) { // 若玩家不存在
+      return; // 直接返回
     } // 条件结束
     this.player.setVelocity(0, 0); // 停止移动
-    this.player.setPosition(this.spawnPoint.x, this.spawnPoint.y); // 移动回出生点
+    this.player.setPosition(this.spawnPoint.x, this.spawnPoint.y); // 返回出生点
   } // 函数结束
-
-  findRoadTile() { // 定义查找道路瓦片的方法
-    if (!this.tileLayer) { // 如果瓦片层尚未创建
-      return null; // 返回空
-    } // 条件结束
-    const roadGid = TILE_INDEX.ROAD + 1; // 计算道路瓦片gid
-    return this.tileLayer.findTile((tile) => tile.index === roadGid); // 在当前层查找道路瓦片
-  } // 方法结束
 } // 类定义结束
 
-// 在脚本加载后立即检查Phaser是否存在并创建游戏实例。
-if (typeof window.Phaser === "undefined") { // 判断全局是否已加载Phaser
-  showAssetMissingMessage("未加载 Phaser 库，请检查网络或CDN。"); // 提示缺少Phaser
-} else { // 若Phaser存在
+// 引导函数：加载配置并启动游戏。
+async function bootstrapGame() { // 定义引导函数
+  const mappingResult = await loadJsonFromPriority(ASSET_PRIORITIES.mapping); // 加载瓦片绑定
+  if (!mappingResult.data) { // 若绑定加载失败
+    showAssetMissingMessage("缺少瓦片绑定配置，请检查 assets/mapping/tileset_binding.json。"); // 提示用户
+    return; // 中止
+  } // 条件结束
+  const bindings = mappingResult.data.bindings || {}; // 读取绑定字典
+  const tileSize = mappingResult.data.tile_size || 32; // 读取瓦片尺寸
+  const tilesPath = await resolveAssetPath(ASSET_PRIORITIES.tiles); // 解析图集路径
+  const playerPath = await resolveAssetPath(ASSET_PRIORITIES.characters.player); // 解析玩家图路径
+  const playerAnimResult = await loadJsonFromPriority(ASSET_PRIORITIES.characters.anim); // 加载动画配置
+  const mapPath = await resolveAssetPath(ASSET_PRIORITIES.maps); // 解析地图路径
+  if (!tilesPath || !playerPath || !playerAnimResult.data || !mapPath) { // 判断是否缺失关键资源
+    showAssetMissingMessage("缺少用户或默认素材，请执行 make user-import 或 make assets 生成资源。"); // 提示用户
+    return; // 中止
+  } // 条件结束
+  const blockedGids = computeBlockedGids(bindings); // 计算阻挡gid
+  runtimeConfig = { // 构造运行时配置
+    tileSize, // 瓦片尺寸
+    bindings, // 绑定字典
+    blockedGids, // 阻挡gid列表
+    assetPaths: { // 资源路径集合
+      tiles: tilesPath, // 图集路径
+      player: playerPath, // 玩家雪碧图路径
+      map: mapPath // 地图路径
+    }, // 资源路径结束
+    playerAnim: playerAnimResult.data, // 玩家动画配置
+    playerSpeed: 140 // 玩家移动速度
+  }; // 配置构建结束
+  if (!window.Phaser) { // 若未加载Phaser
+    showAssetMissingMessage("未加载 Phaser 库，请检查网络或CDN。"); // 提示用户
+    return; // 中止
+  } // 条件结束
   const root = document.getElementById("app-root"); // 获取根节点
-  if (root) { // 确认存在
-    root.innerHTML = ""; // 清空占位文本以放置Canvas
-  } // 结束
-  const config = { // 定义游戏配置
-    type: Phaser.AUTO, // 自动选择渲染器
-    parent: "app-root", // 将Canvas插入到根节点
-    width: TILE_SIZE * 20, // 默认宽度20格
-    height: TILE_SIZE * 15, // 默认高度15格
-    backgroundColor: "#101020", // 设置深色背景
-    pixelArt: true, // 启用像素渲染
-    physics: { // 物理引擎配置
-      default: "arcade", // 使用Arcade物理
-      arcade: { debug: false } // 关闭调试信息
+  if (root) { // 若存在
+    root.innerHTML = ""; // 清空占位内容
+  } // 条件结束
+  const config = { // 构造Phaser配置
+    type: Phaser.AUTO, // 自动选择渲染
+    parent: "app-root", // 指定父节点
+    width: tileSize * 20, // 默认宽度20格
+    height: tileSize * 15, // 默认高度15格
+    backgroundColor: "#101020", // 背景色
+    pixelArt: true, // 开启像素渲染
+    physics: { // 物理配置
+      default: "arcade", // 使用Arcade引擎
+      arcade: { debug: false } // 关闭调试
     }, // 物理配置结束
     scene: MiniWorldScene // 指定场景类
   }; // 配置结束
   // eslint-disable-next-line no-new
-  new Phaser.Game(config); // 启动游戏实例
-} // Phaser存在判断结束
+  new Phaser.Game(config); // 启动游戏
+} // 函数结束
+
+// 监听DOMContentLoaded事件，确保DOM准备就绪后再启动引导。
+document.addEventListener("DOMContentLoaded", () => { // 注册DOMContentLoaded
+  bootstrapGame().catch((error) => { // 调用引导函数并捕获异常
+    console.error("引导游戏失败", error); // 输出错误
+    showAssetMissingMessage("引导失败，请查看控制台日志获取详情。"); // 提示用户
+  }); // 捕获结束
+}); // 事件绑定结束

--- a/scripts/import_user_assets.py
+++ b/scripts/import_user_assets.py
@@ -1,0 +1,333 @@
+"""导入用户素材到标准构建目录并生成所需配置的脚本。"""  # 模块docstring中文描述用途
+from __future__ import annotations  # 引入未来注解语法以提升类型标注兼容性
+
+import argparse  # 导入argparse用于解析命令行参数
+import json  # 导入json模块以读写配置文件
+import math  # 导入math模块以进行打包排布计算
+import shutil  # 导入shutil模块用于复制文件
+import sys  # 导入sys模块用于退出时设定状态码
+from dataclasses import dataclass  # 导入dataclass用于结构化配置
+from pathlib import Path  # 导入Path处理路径操作
+from typing import Any, Dict, List, Optional, Tuple  # 导入类型别名便于注解
+
+from PIL import Image  # 从Pillow导入Image处理图像
+
+
+@dataclass
+class TileImportResult:  # 定义瓦片导入结果的数据类
+    """封装瓦片图集路径与绑定映射等信息。"""  # 数据类docstring中文说明
+
+    tilesheet_path: Optional[Path]  # 记录生成或复制的图集路径
+    bindings: Dict[str, int]  # 记录地形名称到索引的映射
+    tile_size: int  # 记录瓦片尺寸
+
+
+@dataclass
+class CharacterImportResult:  # 定义角色导入结果数据类
+    """封装角色雪碧图路径与动画参数。"""  # 数据类docstring中文说明
+
+    image_path: Optional[Path]  # 记录玩家雪碧图路径
+    anim_config: Dict[str, Any]  # 记录动画配置内容
+
+
+DEFAULT_TILE_NAMES: Tuple[str, ...] = (  # 定义默认地形名称顺序
+    "GRASS",  # 草地
+    "ROAD",  # 道路
+    "TILE_FLOOR",  # 瓷砖地板
+    "WATER",  # 水面
+    "LAKE",  # 湖泊
+    "WALL",  # 墙体
+    "TREE",  # 树木
+    "HOUSE",  # 房屋
+    "ROCK",  # 岩石
+    "LAVA",  # 岩浆
+)  # 元组结束
+
+
+def parse_args() -> argparse.Namespace:  # 定义解析命令行参数的函数
+    """解析命令行参数并返回命名空间。"""  # 函数docstring中文说明
+
+    parser = argparse.ArgumentParser(description="导入用户素材并生成标准构建资源")  # 创建参数解析器并添加描述
+    parser.add_argument("--root", type=Path, default=Path("."), help="设置仓库根目录，默认当前路径")  # 添加根目录参数
+    parser.add_argument("--tile-size", type=int, default=None, help="覆盖瓦片尺寸设置")  # 添加瓦片尺寸覆盖参数
+    parser.add_argument("--frames", type=int, default=None, help="覆盖玩家帧数配置")  # 添加帧数覆盖参数
+    parser.add_argument("--fps", type=int, default=None, help="覆盖玩家动画帧率")  # 添加帧率覆盖参数
+    parser.add_argument("--use-user-map", action="store_true", help="强制启用用户地图")  # 添加强制用户地图开关
+    parser.add_argument("--force", action="store_true", help="忽略尺寸等校验错误继续执行")  # 添加跳过严格校验的选项
+    return parser.parse_args()  # 返回解析结果
+
+
+def load_manifest(manifest_path: Path) -> Dict[str, Any]:  # 定义加载用户清单的函数
+    """读取 manifest JSON 文件，若不存在则返回默认配置。"""  # 函数docstring中文说明
+
+    if manifest_path.exists():  # 判断文件是否存在
+        with manifest_path.open("r", encoding="utf-8") as file:  # 打开文件读取内容
+            return json.load(file)  # 返回解析后的字典
+    # 如果没有 manifest 则提供默认配置
+    return {  # 返回默认配置字典
+        "tile_size": 32,  # 默认瓦片尺寸
+        "tiles": {  # 默认瓦片部分配置
+            "mode": "auto",  # 自动模式
+            "atlas": "tilesheet.png",  # 默认图集文件名
+            "loose_glob": "*.png",  # 默认散瓦片匹配模式
+            "bindings": {},  # 默认绑定为空待后续填充
+        },  # 瓦片配置结束
+        "characters": {  # 默认角色配置
+            "player": {  # 玩家配置块
+                "mode": "atlas",  # 默认使用雪碧图模式
+                "file": "player.png",  # 默认雪碧图文件名
+                "frame_width": 32,  # 默认帧宽
+                "frame_height": 32,  # 默认帧高
+                "frames": 4,  # 默认帧数
+                "fps": 8,  # 默认帧率
+            },  # 玩家配置结束
+        },  # 角色配置结束
+        "maps": {  # 默认地图配置
+            "use_user_map": False,  # 默认不启用用户地图
+            "file": "demo_map.json",  # 默认地图文件名
+        },  # 地图配置结束
+    }  # 默认配置返回
+
+
+def ensure_directory(path: Path) -> None:  # 定义确保目录存在的辅助函数
+    """创建目标目录及其父目录。"""  # 函数docstring中文说明
+
+    path.mkdir(parents=True, exist_ok=True)  # 调用mkdir确保目录存在
+
+
+def validate_tilesheet(image: Image.Image, tile_size: int, force: bool) -> None:  # 定义验证图集尺寸的函数
+    """校验瓦片图集尺寸能被 tile_size 整除。"""  # 函数docstring中文说明
+
+    width, height = image.size  # 读取图像宽高
+    if width % tile_size != 0 or height % tile_size != 0:  # 判断宽高是否整除
+        message = f"瓦片图集尺寸 {width}x{height} 无法被 {tile_size} 整除"  # 构建错误信息
+        if force:  # 若启用强制模式
+            print(f"警告: {message}")  # 打印警告继续执行
+        else:  # 否则视为错误
+            raise ValueError(message)  # 抛出异常终止
+
+
+def copy_tilesheet(source: Path, destination: Path, tile_size: int, force: bool) -> Path:  # 定义复制图集的函数
+    """复制现有图集到构建目录并校验尺寸。"""  # 函数docstring中文说明
+
+    if not source.exists():  # 检查源文件是否存在
+        raise FileNotFoundError(f"找不到图集文件: {source}")  # 抛出异常提示缺失
+    with Image.open(source) as image:  # 打开图像
+        validate_tilesheet(image, tile_size, force)  # 校验尺寸是否符合要求
+    ensure_directory(destination.parent)  # 确保输出目录存在
+    shutil.copy2(source, destination)  # 复制文件保持元数据
+    return destination  # 返回目标路径
+
+
+def pack_loose_tiles(paths: List[Path], destination: Path, tile_size: int, force: bool) -> Path:  # 定义打包散瓦片的函数
+    """将多个散瓦片按字典序拼合为单张图集。"""  # 函数docstring中文说明
+
+    if not paths:  # 若列表为空
+        raise ValueError("未在 tiles 目录找到任何 PNG 文件用于打包")  # 抛出异常提醒
+    sorted_paths = sorted(paths, key=lambda item: item.name)  # 按文件名排序
+    columns = math.ceil(math.sqrt(len(sorted_paths)))  # 计算列数
+    rows = math.ceil(len(sorted_paths) / columns)  # 计算行数
+    sheet = Image.new("RGBA", (columns * tile_size, rows * tile_size), (0, 0, 0, 0))  # 创建空白图集
+    for index, tile_path in enumerate(sorted_paths):  # 遍历每个瓦片
+        with Image.open(tile_path) as tile_image:  # 打开当前瓦片
+            if tile_image.size != (tile_size, tile_size):  # 检查尺寸
+                message = f"散瓦片 {tile_path.name} 尺寸 {tile_image.size} 与 tile_size 不符"  # 构造错误信息
+                if force:  # 如果启用强制模式
+                    print(f"警告: {message}，将按最近邻缩放")  # 打印警告
+                    tile_image = tile_image.resize((tile_size, tile_size), Image.NEAREST)  # 对瓦片缩放
+                else:  # 否则终止
+                    raise ValueError(message)  # 抛出异常
+            sheet.paste(tile_image, ((index % columns) * tile_size, (index // columns) * tile_size))  # 粘贴瓦片到目标位置
+    ensure_directory(destination.parent)  # 确保输出目录存在
+    sheet.save(destination, format="PNG")  # 保存拼合后的图集
+    return destination  # 返回生成路径
+
+
+def resolve_tile_bindings(manifest_bindings: Dict[str, int]) -> Dict[str, int]:  # 定义生成地形绑定的函数
+    """根据 manifest 或默认顺序生成地形索引映射。"""  # 函数docstring中文说明
+
+    if manifest_bindings:  # 若用户提供绑定
+        sorted_items = sorted(manifest_bindings.items(), key=lambda item: item[1])  # 按索引排序确保稳定
+        return {name: index for name, index in sorted_items}  # 返回排序后的映射
+    # 否则按默认顺序分配递增索引
+    return {name: idx for idx, name in enumerate(DEFAULT_TILE_NAMES)}  # 构建默认映射
+
+
+def import_tiles(user_dir: Path, build_dir: Path, tile_config: Dict[str, Any], tile_size: int, force: bool) -> TileImportResult:  # 定义主瓦片导入函数
+    """导入瓦片素材并返回生成的信息。"""  # 函数docstring中文说明
+
+    tiles_dir = user_dir / "tiles"  # 计算用户瓦片目录
+    mode = tile_config.get("mode", "auto")  # 获取模式
+    atlas_name = tile_config.get("atlas", "tilesheet.png")  # 获取图集名称
+    loose_glob = tile_config.get("loose_glob", "*.png")  # 获取散瓦片模式
+    chosen_mode = mode  # 初始化最终模式
+    if mode == "auto":  # 若为自动模式
+        if (tiles_dir / atlas_name).exists():  # 如果发现图集文件
+            chosen_mode = "atlas"  # 选择图集模式
+        else:  # 否则
+            chosen_mode = "loose"  # 选择散瓦片模式
+    build_tilesheet = build_dir / "tiles" / "tilesheet.png"  # 计算输出图集路径
+    tilesheet_path: Optional[Path] = None  # 初始化返回路径
+    if chosen_mode == "atlas":  # 处理图集模式
+        source = tiles_dir / atlas_name  # 计算源路径
+        tilesheet_path = copy_tilesheet(source, build_tilesheet, tile_size, force)  # 复制并校验图集
+    elif chosen_mode == "loose":  # 处理散瓦片模式
+        loose_paths = list(tiles_dir.glob(loose_glob))  # 收集所有匹配的PNG
+        tilesheet_path = pack_loose_tiles(loose_paths, build_tilesheet, tile_size, force)  # 打包为图集
+    else:  # 其他模式暂不支持
+        raise ValueError(f"未知的瓦片导入模式: {mode}")  # 抛出异常
+    bindings = resolve_tile_bindings(tile_config.get("bindings", {}))  # 生成绑定映射
+    print("瓦片导入完成，索引映射如下：")  # 打印提示
+    for name, index in bindings.items():  # 遍历绑定映射
+        print(f"  {name} -> {index}")  # 输出每项绑定
+    return TileImportResult(tilesheet_path=tilesheet_path, bindings=bindings, tile_size=tile_size)  # 返回结果对象
+
+
+def copy_player_sprite(source: Path, destination: Path, frame_width: int, frame_height: int, frames: int, force: bool) -> None:  # 定义复制玩家雪碧图的函数
+    """复制玩家雪碧图并校验尺寸与帧数。"""  # 函数docstring中文说明
+
+    if not source.exists():  # 检查文件存在
+        raise FileNotFoundError(f"找不到玩家雪碧图: {source}")  # 抛出异常
+    with Image.open(source) as image:  # 打开图像
+        width, height = image.size  # 获取尺寸
+        expected_width = frame_width * frames  # 计算期望宽度
+        if height != frame_height or width != expected_width:  # 校验尺寸是否匹配
+            message = f"玩家雪碧图尺寸 {width}x{height} 不符合 {frames} 帧 {frame_width}x{frame_height}"  # 构造错误信息
+            if force:  # 若启用强制模式
+                print(f"警告: {message}")  # 打印警告
+            else:  # 否则终止
+                raise ValueError(message)  # 抛出异常
+    ensure_directory(destination.parent)  # 确保目标目录存在
+    shutil.copy2(source, destination)  # 执行复制
+
+
+def import_characters(user_dir: Path, build_dir: Path, character_config: Dict[str, Any], overrides: Dict[str, Optional[int]], force: bool) -> CharacterImportResult:  # 定义角色导入主函数
+    """导入玩家角色雪碧图并生成动画配置。"""  # 函数docstring中文说明
+
+    player_config = character_config.get("player", {})  # 取得玩家配置字典
+    mode = player_config.get("mode", "atlas")  # 获取模式
+    if mode != "atlas":  # 暂时仅支持atlas
+        raise ValueError("当前仅支持玩家雪碧图的 atlas 模式")  # 抛出异常说明
+    file_name = player_config.get("file", "player.png")  # 获取文件名
+    frame_width = overrides.get("frame_width") or player_config.get("frame_width", 32)  # 确定帧宽
+    frame_height = overrides.get("frame_height") or player_config.get("frame_height", 32)  # 确定帧高
+    frames = overrides.get("frames") or player_config.get("frames", 4)  # 确定帧数
+    fps = overrides.get("fps") or player_config.get("fps", 8)  # 确定帧率
+    source = user_dir / "characters" / file_name  # 计算源文件路径
+    destination = build_dir / "characters" / "player.png"  # 计算目标路径
+    copy_player_sprite(source, destination, frame_width, frame_height, frames, force)  # 执行复制与校验
+    anim_config = {  # 构造动画配置字典
+        "frame_width": frame_width,  # 帧宽
+        "frame_height": frame_height,  # 帧高
+        "frames": frames,  # 帧数量
+        "fps": fps,  # 帧率
+    }  # 字典结束
+    anim_path = build_dir / "characters" / "player.anim.json"  # 计算动画配置输出路径
+    with anim_path.open("w", encoding="utf-8") as file:  # 打开文件写入
+        json.dump(anim_config, file, ensure_ascii=False, indent=2)  # 写入格式化JSON
+    return CharacterImportResult(image_path=destination, anim_config=anim_config)  # 返回结果对象
+
+
+def update_tileset_binding(mapping_path: Path, result: TileImportResult) -> None:  # 定义更新绑定文件的函数
+    """根据瓦片导入结果更新 tileset_binding.json。"""  # 函数docstring中文说明
+
+    ensure_directory(mapping_path.parent)  # 确保目录存在
+    bindings_with_comments: Dict[str, Any] = {  # 构造带注释的映射
+        "_comment": "由 import_user_assets.py 自动生成，请勿手动编辑。",  # 顶部注释
+        "tile_size": result.tile_size,  # 写入瓦片尺寸
+        "bindings": {},  # 初始化绑定字典
+    }  # 字典结束
+    for name, index in result.bindings.items():  # 遍历绑定数据
+        bindings_with_comments["bindings"][f"_comment_{name}"] = f"{name} 的索引"  # 写入注释键
+        bindings_with_comments["bindings"][name] = index  # 写入实际映射
+    with mapping_path.open("w", encoding="utf-8") as file:  # 打开文件写入
+        json.dump(bindings_with_comments, file, ensure_ascii=False, indent=2)  # 输出格式化JSON
+
+
+def copy_user_map(user_dir: Path, frontend_maps_dir: Path, map_config: Dict[str, Any], force_flag: bool) -> Optional[Path]:  # 定义复制用户地图的函数
+    """根据配置决定是否复制用户地图文件。"""  # 函数docstring中文说明
+
+    use_user_map = map_config.get("use_user_map", False)  # 读取是否启用用户地图
+    map_file = map_config.get("file")  # 读取地图文件名
+    if not use_user_map or not map_file:  # 若未启用或未指定文件
+        return None  # 不处理并返回空
+    source = user_dir / "maps" / map_file  # 计算源文件路径
+    if not source.exists():  # 若文件不存在
+        message = f"启用用户地图但找不到文件: {source}"  # 构造错误信息
+        if force_flag:  # 若启用强制模式
+            print(f"警告: {message}")  # 打印警告继续执行
+            return None  # 返回空
+        raise FileNotFoundError(message)  # 抛出异常
+    destination = frontend_maps_dir / "user_map.json"  # 设定目标文件名
+    ensure_directory(destination.parent)  # 确保目标目录存在
+    shutil.copy2(source, destination)  # 执行复制
+    return destination  # 返回目标路径
+
+
+def write_asset_manifest(build_dir: Path, tiles: TileImportResult, characters: CharacterImportResult, user_map_path: Optional[Path]) -> None:  # 定义写入资产清单的函数
+    """生成 asset_manifest.json 描述构建产物的可用性。"""  # 函数docstring中文说明
+
+    manifest = {  # 构造清单字典
+        "tiles": {  # 瓦片部分
+            "path": str(tiles.tilesheet_path) if tiles.tilesheet_path else None,  # 记录图集路径字符串
+            "bindings": tiles.bindings,  # 记录绑定
+            "tile_size": tiles.tile_size,  # 记录瓦片尺寸
+        },  # 瓦片部分结束
+        "characters": {  # 角色部分
+            "player": {  # 玩家配置
+                "image": str(characters.image_path) if characters.image_path else None,  # 记录雪碧图路径
+                "anim": characters.anim_config,  # 记录动画配置
+            }  # 玩家配置结束
+        },  # 角色部分结束
+        "maps": {  # 地图部分
+            "user_map": str(user_map_path) if user_map_path else None,  # 记录用户地图路径
+        },  # 地图部分结束
+    }  # 字典结束
+    manifest_path = build_dir / "asset_manifest.json"  # 计算清单输出路径
+    ensure_directory(manifest_path.parent)  # 确保目录存在
+    with manifest_path.open("w", encoding="utf-8") as file:  # 打开文件写入
+        json.dump(manifest, file, ensure_ascii=False, indent=2)  # 写入格式化JSON
+
+
+def main() -> None:  # 定义主函数
+    """执行导入流程并处理异常。"""  # 函数docstring中文说明
+
+    args = parse_args()  # 解析命令行参数
+    root = args.root.resolve()  # 解析仓库根目录绝对路径
+    user_dir = root / "assets" / "user_imports"  # 计算用户素材目录
+    build_dir = root / "assets" / "build"  # 计算构建目录
+    mapping_path = root / "assets" / "mapping" / "tileset_binding.json"  # 计算绑定文件路径
+    frontend_maps_dir = root / "frontend" / "phaser" / "maps"  # 计算前端地图目录
+    manifest_path = user_dir / "user_manifest.json"  # 计算用户manifest路径
+    manifest = load_manifest(manifest_path)  # 加载manifest或默认值
+    tile_size = args.tile_size or manifest.get("tile_size", 32)  # 根据参数或配置确定瓦片尺寸
+    try:  # 捕获导入过程中的异常
+        tiles_result = import_tiles(user_dir, build_dir, manifest.get("tiles", {}), tile_size, args.force)  # 导入瓦片
+        character_overrides = {  # 构造角色覆盖参数
+            "frame_width": manifest.get("characters", {}).get("player", {}).get("frame_width"),  # 默认帧宽
+            "frame_height": manifest.get("characters", {}).get("player", {}).get("frame_height"),  # 默认帧高
+            "frames": args.frames or manifest.get("characters", {}).get("player", {}).get("frames"),  # 帧数
+            "fps": args.fps or manifest.get("characters", {}).get("player", {}).get("fps"),  # 帧率
+        }  # 覆盖字典结束
+        characters_result = import_characters(  # 调用角色导入函数
+            user_dir,
+            build_dir,
+            manifest.get("characters", {}),
+            character_overrides,
+            args.force,
+        )  # 函数调用结束
+        map_config = manifest.get("maps", {}).copy()  # 获取地图配置副本
+        if args.use_user_map:  # 如果命令行指定启用用户地图
+            map_config["use_user_map"] = True  # 强制开启
+        user_map_path = copy_user_map(user_dir, frontend_maps_dir, map_config, args.force)  # 处理地图复制
+        update_tileset_binding(mapping_path, tiles_result)  # 更新绑定文件
+        write_asset_manifest(build_dir, tiles_result, characters_result, user_map_path)  # 写入构建清单
+        print("导入完成，相关配置已更新。")  # 打印成功信息
+    except Exception as error:  # 捕获所有异常
+        print(f"导入失败: {error}")  # 打印错误信息
+        if not args.force:  # 若未开启强制模式
+            sys.exit(1)  # 设置非零退出码
+
+
+if __name__ == "__main__":  # 判断是否作为脚本运行
+    main()  # 调用主函数

--- a/scripts/verify_user_assets.py
+++ b/scripts/verify_user_assets.py
@@ -1,0 +1,156 @@
+"""校验用户导入素材是否符合尺寸与命名规则的脚本。"""  # 模块docstring中文说明用途
+from __future__ import annotations  # 引入未来注解以提升类型兼容性
+
+import argparse  # 导入argparse解析命令行参数
+import sys  # 导入sys以便设定退出码
+from pathlib import Path  # 导入Path处理文件路径
+from typing import Any, Dict, List  # 导入类型注解辅助
+
+from PIL import Image  # 从Pillow导入Image进行图像校验
+
+from scripts.import_user_assets import (  # 从导入脚本复用函数
+    load_manifest,  # 复用manifest加载逻辑
+    resolve_tile_bindings,  # 复用地形映射生成逻辑
+)  # 导入结束
+
+
+def parse_args() -> argparse.Namespace:  # 定义参数解析函数
+    """解析命令行参数并返回命名空间。"""  # 函数docstring中文说明
+
+    parser = argparse.ArgumentParser(description="校验 assets/user_imports 素材")  # 创建解析器
+    parser.add_argument("--root", type=Path, default=Path("."), help="设置仓库根目录，默认当前路径")  # 添加根目录参数
+    parser.add_argument("--force", action="store_true", help="忽略错误仅输出警告")  # 添加force选项
+    return parser.parse_args()  # 返回解析结果
+
+
+def verify_tiles(user_dir: Path, tile_config: Dict[str, Any], tile_size: int, force: bool) -> List[str]:  # 定义瓦片校验函数
+    """验证瓦片资源是否满足尺寸与文件要求。"""  # 函数docstring中文说明
+
+    tiles_dir = user_dir / "tiles"  # 计算瓦片目录
+    mode = tile_config.get("mode", "auto")  # 读取模式
+    atlas_name = tile_config.get("atlas", "tilesheet.png")  # 获取图集文件名
+    loose_glob = tile_config.get("loose_glob", "*.png")  # 获取散瓦片匹配规则
+    chosen_mode = mode  # 初始化模式
+    messages: List[str] = []  # 准备消息列表
+    if mode == "auto":  # 自动模式判断
+        if (tiles_dir / atlas_name).exists():  # 若存在图集文件
+            chosen_mode = "atlas"  # 选择图集模式
+        else:  # 否则
+            chosen_mode = "loose"  # 选择散瓦片模式
+    if chosen_mode == "atlas":  # 校验图集模式
+        atlas_path = tiles_dir / atlas_name  # 计算图集路径
+        if not atlas_path.exists():  # 若缺少图集
+            message = f"缺少图集文件 {atlas_path}"  # 构造消息
+            messages.append(message)  # 记录错误
+            if not force:  # 若非强制模式
+                raise FileNotFoundError(message)  # 抛出异常
+        else:  # 若文件存在
+            with Image.open(atlas_path) as image:  # 打开图像
+                width, height = image.size  # 读取尺寸
+            if width % tile_size != 0 or height % tile_size != 0:  # 检查整除性
+                message = f"图集尺寸 {width}x{height} 无法被 tile_size {tile_size} 整除"  # 构造错误描述
+                messages.append(message)  # 追加消息
+                if not force:  # 若非强制
+                    raise ValueError(message)  # 抛出异常
+            else:  # 尺寸符合
+                messages.append(f"图集模式通过，共 {width // tile_size * height // tile_size} 格")  # 添加成功信息
+    else:  # 散瓦片模式校验
+        loose_paths = sorted(tiles_dir.glob(loose_glob))  # 按字典序列出瓦片
+        if not loose_paths:  # 若无文件
+            message = f"散瓦片模式下未找到匹配 {loose_glob} 的文件"  # 构造消息
+            messages.append(message)  # 记录
+            if not force:  # 非强制时
+                raise FileNotFoundError(message)  # 抛出异常
+        valid_count = 0  # 初始化计数
+        for path in loose_paths:  # 遍历文件
+            with Image.open(path) as image:  # 打开图像
+                if image.size != (tile_size, tile_size):  # 检查尺寸
+                    message = f"散瓦片 {path.name} 尺寸 {image.size} 与 {tile_size}px 不符"  # 构造消息
+                    messages.append(message)  # 记录
+                    if not force:  # 非强制模式
+                        raise ValueError(message)  # 抛出异常
+                else:  # 尺寸正确
+                    valid_count += 1  # 增加计数
+        messages.append(f"散瓦片模式通过，共 {valid_count} 张瓦片")  # 追加统计信息
+    bindings = resolve_tile_bindings(tile_config.get("bindings", {}))  # 计算绑定以确保存在顺序
+    messages.append(f"地形绑定数量: {len(bindings)}")  # 输出绑定数量
+    return messages  # 返回消息列表
+
+
+def verify_player(user_dir: Path, character_config: Dict[str, Any], force: bool) -> List[str]:  # 定义角色校验函数
+    """验证玩家雪碧图的尺寸信息。"""  # 函数docstring中文说明
+
+    messages: List[str] = []  # 初始化消息列表
+    player_config = character_config.get("player", {})  # 读取玩家配置
+    file_name = player_config.get("file", "player.png")  # 获取文件名
+    frame_width = player_config.get("frame_width", 32)  # 获取帧宽
+    frame_height = player_config.get("frame_height", 32)  # 获取帧高
+    frames = player_config.get("frames", 4)  # 获取帧数
+    sprite_path = user_dir / "characters" / file_name  # 构造文件路径
+    if not sprite_path.exists():  # 若文件不存在
+        message = f"缺少玩家雪碧图 {sprite_path}"  # 构造错误信息
+        messages.append(message)  # 记录错误
+        if not force:  # 非强制模式
+            raise FileNotFoundError(message)  # 抛出异常
+        return messages  # 返回消息
+    with Image.open(sprite_path) as image:  # 打开图片
+        width, height = image.size  # 读取尺寸
+    expected_width = frame_width * frames  # 计算期望宽度
+    if width != expected_width or height != frame_height:  # 校验尺寸
+        message = f"玩家雪碧图尺寸 {width}x{height} 不等于 {frames} 帧 {frame_width}x{frame_height}"  # 构造错误描述
+        messages.append(message)  # 记录
+        if not force:  # 非强制
+            raise ValueError(message)  # 抛出异常
+    else:  # 尺寸正确
+        messages.append(f"玩家雪碧图通过，帧数 {frames}，尺寸 {frame_width}x{frame_height}")  # 输出成功信息
+    fps = player_config.get("fps", 8)  # 读取帧率
+    messages.append(f"玩家动画帧率: {fps} fps")  # 输出帧率信息
+    return messages  # 返回消息列表
+
+
+def verify_maps(user_dir: Path, map_config: Dict[str, Any], force: bool) -> List[str]:  # 定义地图校验函数
+    """验证地图文件是否存在。"""  # 函数docstring中文说明
+
+    messages: List[str] = []  # 初始化消息列表
+    use_user_map = map_config.get("use_user_map", False)  # 读取启用标志
+    map_file = map_config.get("file")  # 读取文件名
+    if not use_user_map or not map_file:  # 若未启用
+        messages.append("未启用用户地图，沿用默认地图")  # 输出信息
+        return messages  # 返回消息列表
+    map_path = user_dir / "maps" / map_file  # 计算地图路径
+    if not map_path.exists():  # 若文件缺失
+        message = f"启用用户地图但找不到 {map_path}"  # 构造错误描述
+        messages.append(message)  # 记录
+        if not force:  # 非强制
+            raise FileNotFoundError(message)  # 抛出异常
+    else:  # 文件存在
+        messages.append(f"用户地图已找到: {map_path.name}")  # 输出成功信息
+    return messages  # 返回消息列表
+
+
+def main() -> None:  # 定义主函数
+    """执行校验并打印总结。"""  # 函数docstring中文说明
+
+    args = parse_args()  # 解析参数
+    root = args.root.resolve()  # 解析根目录
+    user_dir = root / "assets" / "user_imports"  # 计算用户素材目录
+    manifest_path = user_dir / "user_manifest.json"  # 计算manifest路径
+    manifest = load_manifest(manifest_path)  # 加载配置
+    tile_size = manifest.get("tile_size", 32)  # 读取瓦片尺寸
+    print(f"开始校验，瓦片尺寸设定为 {tile_size} 像素")  # 打印标题
+    messages: List[str] = []  # 初始化汇总消息
+    try:  # 捕获潜在异常
+        messages.extend(verify_tiles(user_dir, manifest.get("tiles", {}), tile_size, args.force))  # 校验瓦片
+        messages.extend(verify_player(user_dir, manifest.get("characters", {}), args.force))  # 校验玩家
+        messages.extend(verify_maps(user_dir, manifest.get("maps", {}), args.force))  # 校验地图
+    except Exception as error:  # 捕获异常
+        print(f"校验失败: {error}")  # 输出错误
+        if not args.force:  # 若未启用强制模式
+            sys.exit(1)  # 使用失败退出码
+    for line in messages:  # 遍历所有消息
+        print(f"- {line}")  # 逐条输出
+    print("校验完成。")  # 输出结束语
+
+
+if __name__ == "__main__":  # 判断脚本入口
+    main()  # 调用主函数

--- a/tests/test_user_assets_priority.py
+++ b/tests/test_user_assets_priority.py
@@ -1,0 +1,34 @@
+"""测试前端资源优先级配置确保用户素材优先加载。"""  # 模块docstring中文说明
+from __future__ import annotations  # 引入未来注解兼容性
+
+import json  # 导入json用于解析结构
+import re  # 导入正则表达式提取配置
+from pathlib import Path  # 导入Path处理路径
+
+
+def _extract_priorities(script_path: Path) -> dict[str, object]:  # 定义辅助函数解析JS中的常量
+    """从 main.js 中提取 ASSET_PRIORITIES 常量并转为 Python 字典。"""  # 函数docstring中文说明
+
+    content = script_path.read_text(encoding="utf-8")  # 读取文件内容
+    match = re.search(r"const ASSET_PRIORITIES = (\{.*?\});", content, re.DOTALL)  # 匹配常量块
+    assert match is not None  # 确保找到了配置
+    block = match.group(1)  # 提取原始文本
+    block_no_comments = re.sub(r"//.*", "", block)  # 去除行内注释
+    block_json_ready = re.sub(r"(\w+)\s*:", r'"\1":', block_no_comments)  # 为键补上引号
+    data = json.loads(block_json_ready)  # 解析为字典
+    return data  # 返回结果
+
+
+def test_asset_priorities_user_first() -> None:  # 定义测试函数
+    """确保优先级列表中用户路径排在首位且导出全局变量。"""  # 函数docstring中文说明
+
+    script_path = Path("frontend/phaser/main.js")  # 计算脚本路径
+    data = _extract_priorities(script_path)  # 解析优先级
+    assert data["tiles"][0] == "assets/build/tiles/tilesheet.png"  # 用户瓦片路径应排第一
+    assert data["tiles"][1] == "assets/generated/tiles/tilesheet.png"  # 回退路径排第二
+    assert data["characters"]["player"][0] == "assets/build/characters/player.png"  # 玩家雪碧图优先用户路径
+    assert data["characters"]["anim"][0] == "assets/build/characters/player.anim.json"  # 玩家动画配置优先用户路径
+    assert data["maps"][0] == "maps/user_map.json"  # 用户地图优先
+    assert data["maps"][1] == "maps/demo_map.json"  # 回退地图为演示地图
+    content = script_path.read_text(encoding="utf-8")  # 再次读取文件
+    assert "window.MINIWORLD_ASSET_PRIORITIES" in content  # 确认常量已导出到全局

--- a/tests/test_user_import_pipeline.py
+++ b/tests/test_user_import_pipeline.py
@@ -1,0 +1,80 @@
+"""测试用户素材导入脚本能正确处理最小示例并生成配置。"""  # 模块docstring中文说明用途
+from __future__ import annotations  # 引入未来注解以兼容前向引用
+
+import json  # 导入json模块读取生成的配置
+import subprocess  # 导入subprocess以调用脚本
+import sys  # 导入sys获取当前解释器路径
+from pathlib import Path  # 导入Path处理临时目录
+
+from PIL import Image  # 导入Pillow生成测试用PNG
+
+
+def _create_sample_user_assets(root: Path) -> None:  # 定义内部辅助函数创建测试素材
+    """在临时根目录生成最小瓦片与玩家雪碧图。"""  # 函数docstring中文说明
+
+    tiles_dir = root / "assets" / "user_imports" / "tiles"  # 计算瓦片目录
+    characters_dir = root / "assets" / "user_imports" / "characters"  # 计算角色目录
+    tiles_dir.mkdir(parents=True, exist_ok=True)  # 创建瓦片目录
+    characters_dir.mkdir(parents=True, exist_ok=True)  # 创建角色目录
+    tilesheet = Image.new("RGBA", (64, 64), (0, 255, 0, 255))  # 创建64x64纯色瓦片图集
+    tilesheet.save(tiles_dir / "tilesheet.png")  # 保存图集文件
+    player = Image.new("RGBA", (128, 32), (255, 0, 0, 255))  # 创建128x32玩家雪碧图
+    player.save(characters_dir / "player.png")  # 保存玩家图
+    manifest = {  # 构造简化manifest字典
+        "tile_size": 32,  # 默认瓦片尺寸
+        "tiles": {  # 瓦片配置块
+            "mode": "atlas",  # 使用图集模式
+            "atlas": "tilesheet.png",  # 图集文件名称
+            "bindings": {},  # 使用默认绑定顺序
+        },  # 瓦片配置结束
+        "characters": {  # 角色配置块
+            "player": {  # 玩家配置
+                "mode": "atlas",  # 使用雪碧图模式
+                "file": "player.png",  # 雪碧图文件名
+                "frame_width": 32,  # 单帧宽度
+                "frame_height": 32,  # 单帧高度
+                "frames": 4,  # 帧数
+                "fps": 8,  # 帧率
+            }  # 玩家配置结束
+        },  # 角色配置结束
+        "maps": {  # 地图配置块
+            "use_user_map": False,  # 不启用用户地图
+            "file": "demo_map.json",  # 占位地图文件
+        },  # 地图配置结束
+    }  # 构造简化manifest
+    manifest_path = root / "assets" / "user_imports" / "user_manifest.json"  # 计算manifest路径
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")  # 写入配置
+
+
+def test_import_user_assets_generates_build_outputs(tmp_path: Path) -> None:  # 定义测试函数
+    """验证导入脚本能够生成图集、动画配置与映射。"""  # 函数docstring中文说明
+
+    _create_sample_user_assets(tmp_path)  # 创建最小示例素材
+    mapping_dir = tmp_path / "assets" / "mapping"  # 计算映射目录
+    mapping_dir.mkdir(parents=True, exist_ok=True)  # 创建映射目录
+    script_path = Path("scripts/import_user_assets.py")  # 计算脚本路径
+    result = subprocess.run(  # 调用导入脚本
+        [sys.executable, str(script_path), "--root", str(tmp_path)],  # 构造命令参数
+        check=True,  # 出错抛异常
+        capture_output=True,  # 捕获输出
+        text=True,  # 文本模式
+    )  # 子进程结束
+    assert result.returncode == 0  # 确认脚本执行成功
+    build_tilesheet = tmp_path / "assets" / "build" / "tiles" / "tilesheet.png"  # 计算输出图集路径
+    build_player = tmp_path / "assets" / "build" / "characters" / "player.png"  # 计算玩家输出路径
+    anim_config_path = tmp_path / "assets" / "build" / "characters" / "player.anim.json"  # 动画配置路径
+    binding_path = tmp_path / "assets" / "mapping" / "tileset_binding.json"  # 绑定配置路径
+    assert build_tilesheet.exists()  # 确认图集生成
+    assert build_player.exists()  # 确认玩家图生成
+    assert anim_config_path.exists()  # 确认动画配置生成
+    assert binding_path.exists()  # 确认绑定文件生成
+    with Image.open(build_tilesheet) as image:  # 打开图集验证尺寸
+        assert image.size == (64, 64)  # 图集尺寸应保持64x64
+    with Image.open(build_player) as image:  # 打开玩家图
+        assert image.size == (128, 32)  # 玩家图尺寸保持128x32
+    anim_config = json.loads(anim_config_path.read_text(encoding="utf-8"))  # 读取动画配置
+    assert anim_config["frames"] == 4  # 帧数应为4
+    assert anim_config["frame_width"] == 32  # 帧宽应为32
+    binding_data = json.loads(binding_path.read_text(encoding="utf-8"))  # 读取绑定JSON
+    assert binding_data["tile_size"] == 32  # 瓦片尺寸应为32
+    assert binding_data["bindings"]["GRASS"] == 0  # 默认绑定草地索引为0


### PR DESCRIPTION
## Summary
- add import and verification scripts that normalize assets into assets/build and update bindings
- teach the Phaser frontend to prefer user-provided resources with fallbacks and document the workflow
- expand automation with Makefile helpers, README guidance, and tests covering the new pipeline

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e729dc30688328aaab240292995af3