### PR TITLE
Add miniWorld pixel exploration loop

### DIFF
--- a/miniWorld/.gitignore
+++ b/miniWorld/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+assets_external/

--- a/miniWorld/README.md
+++ b/miniWorld/README.md
@@ -1,0 +1,28 @@
+# MiniWorld
+
+## 第5轮：像素世界探索 v1
+
+### 如何运行
+1. 安装依赖：`pnpm install`
+2. 启动开发服务器：`pnpm dev`
+3. 构建发布版本：`pnpm build`
+4. 预览构建结果：`pnpm preview`
+
+### 外部素材优先级
+- 在 `assets_external/tiles/tilesheet.png` 放置瓦片图集，可自动覆盖占位瓦片。
+- 在 `assets_external/characters/player.png` 放置角色贴图，可自动覆盖占位角色。
+- 如果上述文件缺失，系统会读取 `assets/placeholders/` 元数据，运行时生成占位纹理。
+
+### 按键说明
+- 方向键：移动玩家。
+- `Z`：采集资源。
+- `S`：保存存档。
+- `L`：读取存档。
+
+### 数据结构
+- `TileType`：地形类型枚举，用于地图生成与通行判断。
+- `resourceNodes`：资源点数组，包含坐标、类型与掉落物。
+- `Inventory`：背包条目 `Item`（`id`、`name`、`count`）。
+
+### 后续预告
+第6轮将加入自动对话/跳过、隐藏 UI、术语图鉴、成就等系统。

--- a/miniWorld/assets/placeholders/sprites.meta.json
+++ b/miniWorld/assets/placeholders/sprites.meta.json
@@ -1,0 +1,7 @@
+{
+  "player": {
+    "width": 16,
+    "height": 32,
+    "colors": ["#ffee58", "#fbc02d", "#f57f17"]
+  }
+}

--- a/miniWorld/assets/placeholders/tiles.meta.json
+++ b/miniWorld/assets/placeholders/tiles.meta.json
@@ -1,0 +1,12 @@
+{
+  "GRASS": { "color": "#4caf50", "detail": "#81c784" },
+  "ROAD": { "color": "#8d6e63", "detail": "#a1887f" },
+  "TILE_FLOOR": { "color": "#bdbdbd", "detail": "#eeeeee" },
+  "WATER": { "color": "#2196f3", "detail": "#64b5f6" },
+  "LAKE": { "color": "#1565c0", "detail": "#1e88e5" },
+  "WALL": { "color": "#616161", "detail": "#757575" },
+  "TREE": { "color": "#2e7d32", "detail": "#66bb6a" },
+  "HOUSE": { "color": "#f06292", "detail": "#f48fb1" },
+  "ROCK": { "color": "#455a64", "detail": "#607d8b" },
+  "LAVA": { "color": "#f4511e", "detail": "#ff7043" }
+}

--- a/miniWorld/index.html
+++ b/miniWorld/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MiniWorld</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/miniWorld/package.json
+++ b/miniWorld/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "miniworld",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "phaser": "^3.70.0",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.0",
+    "vitest": "^2.0.4"
+  },
+  "dependencies": {
+    "localforage": "^1.10.0",
+    "pako": "^2.1.0"
+  }
+}

--- a/miniWorld/pnpm-lock.yaml
+++ b/miniWorld/pnpm-lock.yaml
@@ -1,0 +1,906 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      localforage:
+        specifier: ^1.10.0
+        version: 1.10.0
+      pako:
+        specifier: ^2.1.0
+        version: 2.1.0
+    devDependencies:
+      phaser:
+        specifier: ^3.70.0
+        version: 3.90.0
+      typescript:
+        specifier: ^5.6.2
+        version: 5.9.3
+      vite:
+        specifier: ^5.4.0
+        version: 5.4.20
+      vitest:
+        specifier: ^2.0.4
+        version: 2.1.9
+
+packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.52.4':
+    resolution: {integrity: sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.52.4':
+    resolution: {integrity: sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.52.4':
+    resolution: {integrity: sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.52.4':
+    resolution: {integrity: sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.52.4':
+    resolution: {integrity: sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.52.4':
+    resolution: {integrity: sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.4':
+    resolution: {integrity: sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.4':
+    resolution: {integrity: sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.4':
+    resolution: {integrity: sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.52.4':
+    resolution: {integrity: sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.4':
+    resolution: {integrity: sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.4':
+    resolution: {integrity: sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.4':
+    resolution: {integrity: sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.4':
+    resolution: {integrity: sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.4':
+    resolution: {integrity: sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.52.4':
+    resolution: {integrity: sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.52.4':
+    resolution: {integrity: sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.52.4':
+    resolution: {integrity: sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.4':
+    resolution: {integrity: sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.4':
+    resolution: {integrity: sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.52.4':
+    resolution: {integrity: sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.4':
+    resolution: {integrity: sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  lie@3.1.1:
+    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
+
+  localforage@1.10.0:
+    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.19:
+    resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  phaser@3.90.0:
+    resolution: {integrity: sha512-/cziz/5ZIn02uDkC9RzN8VF9x3Gs3XdFFf9nkiMEQT3p7hQlWuyjy4QWosU802qqno2YSLn2BfqwOKLv/sSVfQ==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.52.4:
+    resolution: {integrity: sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.20:
+    resolution: {integrity: sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.52.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.52.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.4':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.20)':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 5.4.20
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.19
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.1: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  eventemitter3@5.0.1: {}
+
+  expect-type@1.2.2: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  immediate@3.0.6: {}
+
+  lie@3.1.1:
+    dependencies:
+      immediate: 3.0.6
+
+  localforage@1.10.0:
+    dependencies:
+      lie: 3.1.1
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.19:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  pako@2.1.0: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  phaser@3.90.0:
+    dependencies:
+      eventemitter3: 5.0.1
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.52.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.4
+      '@rollup/rollup-android-arm64': 4.52.4
+      '@rollup/rollup-darwin-arm64': 4.52.4
+      '@rollup/rollup-darwin-x64': 4.52.4
+      '@rollup/rollup-freebsd-arm64': 4.52.4
+      '@rollup/rollup-freebsd-x64': 4.52.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.4
+      '@rollup/rollup-linux-arm64-gnu': 4.52.4
+      '@rollup/rollup-linux-arm64-musl': 4.52.4
+      '@rollup/rollup-linux-loong64-gnu': 4.52.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.4
+      '@rollup/rollup-linux-riscv64-musl': 4.52.4
+      '@rollup/rollup-linux-s390x-gnu': 4.52.4
+      '@rollup/rollup-linux-x64-gnu': 4.52.4
+      '@rollup/rollup-linux-x64-musl': 4.52.4
+      '@rollup/rollup-openharmony-arm64': 4.52.4
+      '@rollup/rollup-win32-arm64-msvc': 4.52.4
+      '@rollup/rollup-win32-ia32-msvc': 4.52.4
+      '@rollup/rollup-win32-x64-gnu': 4.52.4
+      '@rollup/rollup-win32-x64-msvc': 4.52.4
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.9.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  typescript@5.9.3: {}
+
+  vite-node@2.1.9:
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.20
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.20:
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.52.4
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@2.1.9:
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.20)
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.19
+      pathe: 1.1.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.20
+      vite-node: 2.1.9
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/miniWorld/src/config/keys.ts
+++ b/miniWorld/src/config/keys.ts
@@ -1,0 +1,7 @@
+export const KEY_UP = 'UP'; // 上方向键常量
+export const KEY_DOWN = 'DOWN'; // 下方向键常量
+export const KEY_LEFT = 'LEFT'; // 左方向键常量
+export const KEY_RIGHT = 'RIGHT'; // 右方向键常量
+export const KEY_INTERACT = 'Z'; // 交互采集键
+export const KEY_SAVE = 'S'; // 保存键
+export const KEY_LOAD = 'L'; // 读取键

--- a/miniWorld/src/config/pixel.ts
+++ b/miniWorld/src/config/pixel.ts
@@ -1,0 +1,1 @@
+export const PIXEL_CONFIG = { antialias: false, roundPixels: true, mipmap: false }; // 导出全局像素渲染约定

--- a/miniWorld/src/core/Loader.ts
+++ b/miniWorld/src/core/Loader.ts
@@ -1,0 +1,97 @@
+import Phaser from 'phaser'; // 引入Phaser框架
+import { TextureFactory, TilesMeta, SpritesMeta } from './TextureFactory'; // 引入纹理工厂与类型
+import { TileType } from '../world/Types'; // 引入地形类型
+// 分隔注释 // 保持行有注释
+const TILE_SEQUENCE: TileType[] = ['GRASS', 'ROAD', 'TILE_FLOOR', 'WATER', 'LAKE', 'WALL', 'TREE', 'HOUSE', 'ROCK', 'LAVA']; // 定义瓦片顺序常量
+const TILE_SHEET_KEY = 'external_tilesheet'; // 定义外部瓦片图集键名
+const PLAYER_SHEET_KEY = 'external_player'; // 定义外部角色图集键名
+let assetSourceLabel = '占位纹理'; // 默认素材来源标签
+// 分隔注释 // 保持行有注释
+async function assetExists(url: string): Promise<boolean> { // 判断资源是否存在的辅助函数
+  try { // 尝试发起请求
+    const response = await fetch(url, { method: 'HEAD' }); // 使用HEAD请求检查资源
+    return response.ok; // 返回响应是否成功
+  } catch (error) { // 捕获异常
+    return false; // 发生异常则视为不存在
+  } // 结束异常捕获
+} // 函数结束
+// 分隔注释 // 保持行有注释
+function transferFrame(scene: Phaser.Scene, sheetKey: string, textureKey: string, frameIndex: number): void { // 将图集帧复制为独立纹理
+  const sourceTexture = scene.textures.get(sheetKey); // 获取图集纹理
+  const frame = sourceTexture.get(frameIndex); // 根据帧序号取得帧对象
+  if (!frame) { // 如果帧不存在
+    return; // 提前返回
+  } // 结束检查
+  const canvas = scene.textures.createCanvas(textureKey, frame.width, frame.height); // 创建画布纹理作为目标
+  const context = canvas.context; // 获取2D绘图上下文
+  context.imageSmoothingEnabled = false; // 禁用平滑确保像素清晰
+  context.drawImage(frame.source.image, frame.cutX, frame.cutY, frame.cutWidth, frame.cutHeight, 0, 0, frame.width, frame.height); // 将帧绘制到画布
+  canvas.refresh(); // 刷新纹理数据
+} // 函数结束
+// 分隔注释 // 保持行有注释
+async function loadExternalTiles(scene: Phaser.Scene): Promise<boolean> { // 加载外部瓦片素材
+  const sheetUrl = '/tiles/tilesheet.png'; // 定义瓦片图集路径
+  const exists = await assetExists(sheetUrl); // 检查资源是否存在
+  if (!exists) { // 如果不存在
+    return false; // 返回失败
+  } // 结束检查
+  await new Promise<void>((resolve) => { // 创建等待加载完成的Promise
+    scene.load.spritesheet(TILE_SHEET_KEY, sheetUrl, { frameWidth: 32, frameHeight: 32 }); // 注册瓦片图集加载
+    scene.load.once(Phaser.Loader.Events.COMPLETE, () => resolve()); // 加载完成时解析Promise
+    scene.load.start(); // 启动加载流程
+  }); // Promise结束
+  TILE_SEQUENCE.forEach((type, index) => { // 遍历所有地形类型
+    const targetKey = `tile_${type}`; // 生成目标纹理键
+    if (scene.textures.exists(targetKey)) { // 如果纹理已存在
+      scene.textures.remove(targetKey); // 先移除旧纹理
+    } // 结束检查
+    transferFrame(scene, TILE_SHEET_KEY, targetKey, index); // 复制对应帧为独立纹理
+  }); // 遍历结束
+  return true; // 返回加载成功
+} // 函数结束
+// 分隔注释 // 保持行有注释
+async function loadExternalPlayer(scene: Phaser.Scene): Promise<boolean> { // 加载外部角色素材
+  const playerUrl = '/characters/player.png'; // 定义角色贴图路径
+  const exists = await assetExists(playerUrl); // 检查资源是否存在
+  if (!exists) { // 如果不存在
+    return false; // 返回失败
+  } // 结束检查
+  await new Promise<void>((resolve) => { // 创建加载Promise
+    scene.load.spritesheet(PLAYER_SHEET_KEY, playerUrl, { frameWidth: 16, frameHeight: 32 }); // 注册角色图集加载
+    scene.load.once(Phaser.Loader.Events.COMPLETE, () => resolve()); // 完成时解析Promise
+    scene.load.start(); // 启动加载流程
+  }); // Promise结束
+  if (scene.anims.exists('player_walk')) { // 如果已有玩家动画
+    scene.anims.remove('player_walk'); // 移除旧动画
+  } // 结束检查
+  const texture = scene.textures.get(PLAYER_SHEET_KEY); // 获取外部角色纹理
+  const frameTotal = texture.frameTotal; // 获取帧数量
+  for (let index = 0; index < frameTotal; index += 1) { // 遍历帧序号
+    const frameKey = `player_idle_${index}`; // 生成帧纹理键
+    if (scene.textures.exists(frameKey)) { // 如果纹理已存在
+      scene.textures.remove(frameKey); // 移除旧纹理
+    } // 结束检查
+    transferFrame(scene, PLAYER_SHEET_KEY, frameKey, index); // 拷贝帧到独立纹理
+  } // 循环结束
+  scene.anims.create({ key: 'player_walk', frames: new Array(frameTotal).fill(0).map((_, idx) => ({ key: `player_idle_${idx}` })), frameRate: 6, repeat: -1 }); // 使用外部帧创建动画
+  return true; // 返回加载成功
+} // 函数结束
+// 分隔注释 // 保持行有注释
+export async function loadOrFallback(scene: Phaser.Scene): Promise<void> { // 统一加载外部或占位素材
+  const tilesMeta: TilesMeta = TextureFactory.loadBuiltinTilesMeta(); // 获取内置瓦片元数据
+  const spritesMeta: SpritesMeta = TextureFactory.loadBuiltinSpritesMeta(); // 获取内置角色元数据
+  const tilesLoaded = await loadExternalTiles(scene); // 尝试加载外部瓦片
+  const playerLoaded = await loadExternalPlayer(scene); // 尝试加载外部角色
+  if (!tilesLoaded) { // 如果外部瓦片缺失
+    TextureFactory.createTileTextures(scene, tilesMeta); // 生成占位瓦片
+  } // 条件结束
+  if (!playerLoaded) { // 如果外部角色缺失
+    TextureFactory.createPlayerTextures(scene, spritesMeta); // 生成占位角色
+  } // 条件结束
+  assetSourceLabel = tilesLoaded || playerLoaded ? '外部素材' : '占位纹理'; // 根据加载结果记录来源标签
+  scene.registry.set('assetSource', assetSourceLabel); // 将标签写入注册表供HUD使用
+} // 函数结束
+// 分隔注释 // 保持行有注释
+export function getAssetSourceLabel(): string { // 导出素材来源读取函数
+  return assetSourceLabel; // 返回当前标签
+} // 函数结束

--- a/miniWorld/src/core/TextureFactory.ts
+++ b/miniWorld/src/core/TextureFactory.ts
@@ -1,0 +1,69 @@
+import Phaser from 'phaser'; // 引入Phaser框架
+import tilesMetaData from '../../assets/placeholders/tiles.meta.json'; // 引入瓦片占位元数据
+import spritesMetaData from '../../assets/placeholders/sprites.meta.json'; // 引入角色占位元数据
+// 分隔注释 // 保持行有注释
+export type TilesMeta = Record<string, { color: string; detail: string }>; // 定义瓦片元数据类型
+export type SpritesMeta = { player: { width: number; height: number; colors: string[] } }; // 定义角色元数据类型
+// 分隔注释 // 保持行有注释
+export class TextureFactory { // 导出纹理工厂类
+  public static createTileTextures(scene: Phaser.Scene, meta: TilesMeta): void { // 创建瓦片纹理方法
+    const size = 32; // 定义瓦片尺寸
+    Object.entries(meta).forEach(([key, value]) => { // 遍历每个瓦片定义
+      const textureKey = `tile_${key}`; // 生成纹理键名
+      if (scene.textures.exists(textureKey)) { // 如果纹理已存在
+        scene.textures.remove(textureKey); // 先移除旧纹理
+      } // 结束存在判断
+      const canvas = scene.textures.createCanvas(textureKey, size, size); // 创建画布纹理
+      const context = canvas.context; // 获取2D上下文
+      context.imageSmoothingEnabled = false; // 禁用平滑确保像素风
+      context.fillStyle = value.color; // 设置主色
+      context.fillRect(0, 0, size, size); // 填充背景色
+      context.fillStyle = value.detail; // 设置细节色
+      context.fillRect(4, 4, 8, 8); // 绘制左上角细节
+      context.fillRect(size - 12, size - 12, 8, 8); // 绘制右下角细节
+      context.fillRect(size / 2 - 2, size / 2 - 2, 4, 4); // 绘制中心像素
+      canvas.refresh(); // 刷新纹理数据
+    }); // 结束遍历
+  } // 方法结束
+
+  public static createPlayerTextures(scene: Phaser.Scene, meta: SpritesMeta): void { // 创建玩家纹理方法
+    const baseKey = 'player_idle'; // 定义基础纹理键
+    const frameCount = 2; // 定义帧数量
+    const width = meta.player.width; // 读取宽度
+    const height = meta.player.height; // 读取高度
+    for (let i = 0; i < frameCount; i += 1) { // 遍历每帧
+      const textureKey = `${baseKey}_${i}`; // 组合帧纹理键
+      if (scene.textures.exists(textureKey)) { // 检查纹理是否存在
+        scene.textures.remove(textureKey); // 移除旧纹理
+      } // 结束检查
+      const canvas = scene.textures.createCanvas(textureKey, width, height); // 创建画布纹理
+      const context = canvas.context; // 获取2D上下文
+      context.imageSmoothingEnabled = false; // 禁用平滑
+      context.fillStyle = meta.player.colors[0]; // 使用第一种颜色填充背景
+      context.fillRect(0, 0, width, height); // 填充整个人物轮廓
+      context.fillStyle = meta.player.colors[1]; // 使用第二种颜色绘制衣服
+      context.fillRect(2, height / 2, width - 4, height / 2 - 2); // 绘制下半部分服装
+      context.fillStyle = meta.player.colors[2]; // 使用第三种颜色绘制细节
+      context.fillRect(width / 2 - 2, 6, 4, 4); // 绘制面部特征
+      context.fillRect(4 + i, height - 6, width / 2 - 4, 4); // 绘制左腿随帧摆动
+      context.fillRect(width / 2 + i, height - 6, width / 2 - 4, 4); // 绘制右腿随帧摆动
+      canvas.refresh(); // 刷新纹理
+    } // 结束循环
+    if (!scene.anims.exists('player_walk')) { // 检查动画是否已存在
+      scene.anims.create({ // 创建玩家行走动画
+        key: 'player_walk', // 动画键名
+        frames: [{ key: `${baseKey}_0` }, { key: `${baseKey}_1` }], // 动画帧数组
+        frameRate: 6, // 帧率设置
+        repeat: -1, // 循环播放
+      }); // 完成动画创建
+    } // 动画检查结束
+  } // 方法结束
+
+  public static loadBuiltinTilesMeta(): TilesMeta { // 加载内置瓦片元数据
+    return tilesMetaData as TilesMeta; // 返回类型断言后的数据
+  } // 方法结束
+
+  public static loadBuiltinSpritesMeta(): SpritesMeta { // 加载内置角色元数据
+    return spritesMetaData as SpritesMeta; // 返回类型断言后的数据
+  } // 方法结束
+} // 类结束

--- a/miniWorld/src/game.ts
+++ b/miniWorld/src/game.ts
@@ -1,0 +1,18 @@
+import Phaser from 'phaser'; // 引入Phaser框架
+import BootScene from './scenes/BootScene'; // 引入启动场景
+import WorldScene from './scenes/WorldScene'; // 引入世界场景
+import { PIXEL_CONFIG } from './config/pixel'; // 引入像素渲染配置
+// 分隔注释 // 保持行有注释
+export function createMiniWorldGame(): Phaser.Game { // 导出创建游戏实例的函数
+  const config: Phaser.Types.Core.GameConfig = { // 定义游戏配置对象
+    type: Phaser.AUTO, // 自动选择渲染方式
+    width: 320, // 设置游戏宽度
+    height: 320, // 设置游戏高度
+    parent: 'app', // 挂载到页面上的节点
+    backgroundColor: '#1d1f21', // 设置背景颜色
+    scene: [BootScene, WorldScene], // 注册场景顺序
+    scale: { mode: Phaser.Scale.FIT, autoCenter: Phaser.Scale.CENTER_BOTH, zoom: 2 }, // 缩放与居中设置
+    render: { pixelArt: true, antialias: PIXEL_CONFIG.antialias, roundPixels: PIXEL_CONFIG.roundPixels, mipmapFilter: PIXEL_CONFIG.mipmap ? Phaser.Textures.FilterMode.LINEAR : Phaser.Textures.FilterMode.NEAREST }, // 像素渲染配置
+  }; // 结束配置对象
+  return new Phaser.Game(config); // 创建并返回游戏实例
+} // 函数结束

--- a/miniWorld/src/main.ts
+++ b/miniWorld/src/main.ts
@@ -1,0 +1,3 @@
+import { createMiniWorldGame } from './game'; // 引入创建游戏的方法
+// 分隔注释 // 保持行有注释
+createMiniWorldGame(); // 立即创建游戏实例

--- a/miniWorld/src/scenes/BootScene.ts
+++ b/miniWorld/src/scenes/BootScene.ts
@@ -1,0 +1,23 @@
+import Phaser from 'phaser'; // 引入Phaser框架
+import { loadOrFallback } from '../core/Loader'; // 引入资源加载器
+// 分隔注释 // 保持行有注释
+export default class BootScene extends Phaser.Scene { // 定义启动场景
+  private loadingLabel?: Phaser.GameObjects.Text; // 存储加载文本引用
+  // 分隔注释 // 保持行有注释
+  public constructor() { // 构造函数
+    super('BootScene'); // 调用父类并设定场景键名
+  } // 构造结束
+  // 分隔注释 // 保持行有注释
+  public preload(): void { // 预加载阶段
+    this.loadingLabel = this.add.text(160, 160, '加载中...', { fontFamily: 'sans-serif', fontSize: '16px', color: '#ffffff' }); // 创建加载文本
+    this.loadingLabel.setOrigin(0.5); // 设置文本居中
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  public async create(): Promise<void> { // 创建阶段
+    await loadOrFallback(this); // 执行资源加载
+    if (this.loadingLabel) { // 如果存在文本
+      this.loadingLabel.setText('加载完成'); // 更新文案
+    } // 条件结束
+    this.scene.start('WorldScene'); // 切换到世界场景
+  } // 方法结束
+} // 类结束

--- a/miniWorld/src/scenes/WorldScene.ts
+++ b/miniWorld/src/scenes/WorldScene.ts
@@ -1,0 +1,236 @@
+import Phaser from 'phaser'; // 引入Phaser框架
+import { KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT, KEY_INTERACT, KEY_SAVE, KEY_LOAD } from '../config/keys'; // 引入按键常量
+import { genDemoMap, isWalkable, layerOf } from '../world/TileRules'; // 引入地图工具
+import { TileCell, GridPos } from '../world/Types'; // 引入类型定义
+import { getNodeAt, removeNodeAt } from '../world/Nodes'; // 引入资源节点接口
+import { Inventory } from '../systems/Inventory'; // 引入背包系统
+import { save, load, buildState, applyState } from '../systems/SaveLoad'; // 引入存档系统
+import { LabelManager } from '../ui/LabelManager'; // 引入提示管理器
+import { PopupManager } from '../ui/PopupManager'; // 引入飘字管理器
+// 分隔注释 // 保持行有注释
+const TILE_SIZE = 32; // 定义瓦片像素大小
+// 分隔注释 // 保持行有注释
+export default class WorldScene extends Phaser.Scene { // 定义世界场景
+  private mapData: TileCell[][] = []; // 保存地图数据
+  private tileSprites: Phaser.GameObjects.Image[][] = []; // 保存瓦片精灵引用
+  private playerContainer!: Phaser.GameObjects.Container; // 保存玩家容器
+  private playerSprite!: Phaser.GameObjects.Sprite; // 保存玩家精灵
+  private inventory: Inventory = new Inventory(); // 初始化背包
+  private labelManager!: LabelManager; // 提示管理器引用
+  private popupManager!: PopupManager; // 飘字管理器引用
+  private cursors!: { up: Phaser.Input.Keyboard.Key; down: Phaser.Input.Keyboard.Key; left: Phaser.Input.Keyboard.Key; right: Phaser.Input.Keyboard.Key; }; // 方向按键引用
+  private interactKey!: Phaser.Input.Keyboard.Key; // 交互按键引用
+  private saveKey!: Phaser.Input.Keyboard.Key; // 保存按键引用
+  private loadKey!: Phaser.Input.Keyboard.Key; // 读取按键引用
+  private hudSourceText!: Phaser.GameObjects.Text; // 素材来源文本
+  private hudControlsText!: Phaser.GameObjects.Text; // 操作提示文本
+  private playerSpeed = 80; // 玩家移动速度
+  // 分隔注释 // 保持行有注释
+  public constructor() { // 构造函数
+    super('WorldScene'); // 调用父类构造并设定场景键名
+  } // 构造结束
+  // 分隔注释 // 保持行有注释
+  public create(): void { // 场景创建时调用
+    this.mapData = genDemoMap(10, 10); // 生成演示地图
+    this.renderMap(); // 渲染瓦片
+    this.createPlayer(); // 创建玩家实体
+    this.labelManager = new LabelManager(this); // 初始化提示管理器
+    this.popupManager = new PopupManager(this); // 初始化飘字管理器
+    this.setupInput(); // 配置输入
+    this.createHUD(); // 创建界面
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private renderMap(): void { // 渲染地图方法
+    this.tileSprites.forEach((row) => row.forEach((sprite) => sprite.destroy())); // 清理旧瓦片
+    this.tileSprites = []; // 重置数组
+    this.mapData.forEach((row, y) => { // 遍历行
+      const spriteRow: Phaser.GameObjects.Image[] = []; // 初始化行精灵数组
+      row.forEach((cell, x) => { // 遍历列
+        const textureKey = `tile_${cell.type}`; // 计算纹理键
+        const image = this.add.image(x * TILE_SIZE + TILE_SIZE / 2, y * TILE_SIZE + TILE_SIZE / 2, textureKey); // 创建瓦片图像
+        image.setOrigin(0.5, 0.5); // 设置锚点
+        image.setDepth(layerOf(cell) === 'overpass' ? 200 + y : y); // 根据层位设置深度
+        spriteRow.push(image); // 保存引用
+      }); // 列遍历结束
+      this.tileSprites.push(spriteRow); // 将行加入数组
+    }); // 行遍历结束
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private createPlayer(): void { // 创建玩家实体
+    const startGrid: GridPos = { x: 1, y: 5 }; // 定义初始网格
+    const worldX = startGrid.x * TILE_SIZE + TILE_SIZE / 2; // 计算像素X
+    const worldY = startGrid.y * TILE_SIZE + TILE_SIZE / 2; // 计算像素Y
+    this.playerContainer = this.add.container(worldX, worldY); // 创建容器
+    this.playerSprite = this.add.sprite(0, 0, 'player_idle_0'); // 创建精灵
+    this.playerSprite.setOrigin(0.5, 1); // 设置锚点
+    this.playerSprite.play('player_walk'); // 播放行走动画
+    this.playerContainer.add(this.playerSprite); // 将精灵加入容器
+    this.updatePlayerDepth(); // 根据位置更新深度
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private setupInput(): void { // 配置按键
+    this.cursors = this.input.keyboard.addKeys({ up: KEY_UP, down: KEY_DOWN, left: KEY_LEFT, right: KEY_RIGHT }) as { up: Phaser.Input.Keyboard.Key; down: Phaser.Input.Keyboard.Key; left: Phaser.Input.Keyboard.Key; right: Phaser.Input.Keyboard.Key; }; // 创建方向键映射
+    this.interactKey = this.input.keyboard.addKey(KEY_INTERACT); // 创建交互键
+    this.saveKey = this.input.keyboard.addKey(KEY_SAVE); // 创建保存键
+    this.loadKey = this.input.keyboard.addKey(KEY_LOAD); // 创建读取键
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private createHUD(): void { // 创建界面元素
+    const source = this.registry.get('assetSource') as string | undefined; // 读取素材来源
+    this.hudSourceText = this.add.text(8, 8, `素材来源：${source ?? '占位纹理'}`, { fontFamily: 'sans-serif', fontSize: '12px', color: '#ffffff', backgroundColor: 'rgba(0,0,0,0.66)', padding: { x: 4, y: 2 } }); // 创建左上角文本
+    this.hudSourceText.setDepth(1200); // 设置渲染深度
+    this.hudControlsText = this.add.text(312, 312, 'Z 采集 / S 保存 / L 读取', { fontFamily: 'sans-serif', fontSize: '12px', color: '#ffffff', backgroundColor: 'rgba(0,0,0,0.66)', padding: { x: 4, y: 2 }, align: 'right' }); // 创建右下角提示
+    this.hudControlsText.setOrigin(1, 1); // 设置锚点
+    this.hudControlsText.setDepth(1200); // 设置深度
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  public update(_: number, delta: number): void { // 每帧更新
+    this.handleMovement(delta); // 更新移动
+    this.handleInteractionInput(); // 处理采集按键
+    this.handleSaveLoadInput(); // 处理存读按键
+    this.updateResourceHint(); // 更新提示
+    this.popupManager.update(delta); // 更新飘字动画
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private handleMovement(delta: number): void { // 处理玩家移动
+    const horizontal = (this.cursors.right.isDown ? 1 : 0) - (this.cursors.left.isDown ? 1 : 0); // 计算水平输入
+    const vertical = (this.cursors.down.isDown ? 1 : 0) - (this.cursors.up.isDown ? 1 : 0); // 计算垂直输入
+    const direction = new Phaser.Math.Vector2(horizontal, vertical); // 构造方向向量
+    if (direction.lengthSq() > 0) { // 如果有输入
+      direction.normalize(); // 归一化向量
+      if (!this.playerSprite.anims.isPlaying) { // 如果动画未播放
+        this.playerSprite.play('player_walk'); // 播放动画
+      } // 条件结束
+    } else { // 没有输入
+      if (this.playerSprite.anims.isPlaying) { // 如果动画播放中
+        this.playerSprite.anims.stop(); // 停止动画
+        this.playerSprite.setTexture('player_idle_0'); // 切换到静止帧
+      } // 条件结束
+    } // 输入判断结束
+    const deltaSeconds = delta / 1000; // 转换为秒
+    let newX = this.playerContainer.x; // 初始化新X
+    let newY = this.playerContainer.y; // 初始化新Y
+    if (direction.x !== 0) { // 如果存在水平移动
+      const candidateX = newX + direction.x * this.playerSpeed * deltaSeconds; // 计算目标X
+      const tileX = Math.floor(candidateX / TILE_SIZE); // 计算目标网格X
+      const tileY = Math.floor(newY / TILE_SIZE); // 当前网格Y
+      if (this.canMoveTo(tileX, tileY)) { // 判断是否可走
+        newX = candidateX; // 更新位置
+      } // 条件结束
+    } // 水平结束
+    if (direction.y !== 0) { // 如果存在垂直移动
+      const candidateY = newY + direction.y * this.playerSpeed * deltaSeconds; // 计算目标Y
+      const tileX = Math.floor(newX / TILE_SIZE); // 当前网格X
+      const tileY = Math.floor(candidateY / TILE_SIZE); // 目标网格Y
+      if (this.canMoveTo(tileX, tileY)) { // 判断是否可走
+        newY = candidateY; // 更新位置
+      } // 条件结束
+    } // 垂直结束
+    const mapWidth = this.mapData[0]?.length ?? 0; // 地图宽度
+    const mapHeight = this.mapData.length; // 地图高度
+    const minX = TILE_SIZE / 2; // 最小X
+    const maxX = mapWidth * TILE_SIZE - TILE_SIZE / 2; // 最大X
+    const minY = TILE_SIZE / 2; // 最小Y
+    const maxY = mapHeight * TILE_SIZE - TILE_SIZE / 2; // 最大Y
+    this.playerContainer.x = Phaser.Math.Clamp(newX, minX, maxX); // 应用X位置
+    this.playerContainer.y = Phaser.Math.Clamp(newY, minY, maxY); // 应用Y位置
+    this.updatePlayerDepth(); // 更新深度
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private canMoveTo(tileX: number, tileY: number): boolean { // 判断是否可移动到目标网格
+    if (tileY < 0 || tileY >= this.mapData.length) { // 检查纵向越界
+      return false; // 返回不可行
+    } // 条件结束
+    if (tileX < 0 || tileX >= this.mapData[0].length) { // 检查横向越界
+      return false; // 返回不可行
+    } // 条件结束
+    return isWalkable(this.mapData[tileY][tileX]); // 返回通行结果
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private updatePlayerDepth(): void { // 根据所在瓦片更新深度
+    const grid = this.getPlayerGrid(); // 获取玩家所在格子
+    const cell = this.mapData[grid.y]?.[grid.x]; // 获取单元格
+    if (cell) { // 如果存在
+      const baseDepth = layerOf(cell) === 'overpass' ? 600 : 400; // 根据层位确定深度基准
+      this.playerContainer.setDepth(baseDepth + grid.y); // 设置深度
+    } // 条件结束
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private getPlayerGrid(): GridPos { // 计算玩家当前网格坐标
+    return { x: Math.floor(this.playerContainer.x / TILE_SIZE), y: Math.floor(this.playerContainer.y / TILE_SIZE) }; // 返回坐标
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private handleInteractionInput(): void { // 处理交互输入
+    if (Phaser.Input.Keyboard.JustDown(this.interactKey)) { // 如果按下交互键
+      this.tryCollectNode(); // 执行采集
+    } // 条件结束
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private tryCollectNode(): void { // 尝试采集资源节点
+    const grid = this.getPlayerGrid(); // 获取玩家位置
+    const node = getNodeAt(grid); // 查询资源节点
+    if (!node) { // 如果没有节点
+      return; // 直接返回
+    } // 条件结束
+    this.inventory.add(node.loot.id, node.loot.name, node.loot.count); // 将物品加入背包
+    removeNodeAt(grid); // 移除节点
+    this.mapData[grid.y][grid.x] = { type: 'GRASS', layerTag: 'ground' }; // 将格子恢复为草地
+    this.updateTileTexture(grid.x, grid.y); // 更新瓦片显示
+    this.labelManager.hideAll(); // 隐藏提示
+    this.popupManager.popup(this.playerContainer.x, this.playerContainer.y - TILE_SIZE / 2, `+${node.loot.count} ${node.loot.name}`, node.type === 'TREE' ? '#88ff88' : node.type === 'ROCK' ? '#ccccff' : '#ff99ff'); // 显示飘字
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private updateTileTexture(x: number, y: number): void { // 更新单个瓦片纹理
+    const cell = this.mapData[y]?.[x]; // 获取单元格
+    const sprite = this.tileSprites[y]?.[x]; // 获取对应精灵
+    if (cell && sprite) { // 如果存在
+      sprite.setTexture(`tile_${cell.type}`); // 更新纹理
+      sprite.setDepth(layerOf(cell) === 'overpass' ? 200 + y : y); // 更新深度
+    } // 条件结束
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private updateResourceHint(): void { // 更新资源提示
+    const grid = this.getPlayerGrid(); // 获取玩家位置
+    const node = getNodeAt(grid); // 查找节点
+    if (node) { // 如果存在
+      this.labelManager.showHintAt(this.playerContainer.x, this.playerContainer.y - this.playerSprite.displayHeight, '按 Z 采集'); // 显示提示
+    } else { // 否则
+      this.labelManager.hideAll(); // 隐藏提示
+    } // 条件结束
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private handleSaveLoadInput(): void { // 处理存读输入
+    if (Phaser.Input.Keyboard.JustDown(this.saveKey)) { // 检测保存键
+      void this.performSave(); // 执行保存
+    } // 条件结束
+    if (Phaser.Input.Keyboard.JustDown(this.loadKey)) { // 检测读取键
+      void this.performLoad(); // 执行读取
+    } // 条件结束
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private async performSave(): Promise<void> { // 执行保存逻辑
+    const state = buildState({ map: this.mapData }, { x: this.playerContainer.x, y: this.playerContainer.y }, this.inventory); // 构建状态
+    await save('slot1', state); // 保存到固定存档位
+    this.popupManager.popup(this.playerContainer.x, this.playerContainer.y - TILE_SIZE, '保存成功', '#66ccff'); // 提示保存成功
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private async performLoad(): Promise<void> { // 执行读取逻辑
+    const data = await load('slot1'); // 读取存档
+    if (!data) { // 如果没有存档
+      this.popupManager.popup(this.playerContainer.x, this.playerContainer.y - TILE_SIZE, '无存档', '#ffcc66'); // 提示无存档
+      return; // 结束函数
+    } // 条件结束
+    applyState(data as ReturnType<typeof buildState>, { setMapData: (map) => this.setMapData(map) }, { setPosition: (x, y) => this.setPlayerPosition(x, y) }, this.inventory); // 应用状态
+    this.renderMap(); // 重新渲染地图
+    this.popupManager.popup(this.playerContainer.x, this.playerContainer.y - TILE_SIZE, '读取成功', '#66ffcc'); // 提示读取成功
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  public setMapData(map: TileCell[][]): void { // 外部接口用于更新地图
+    this.mapData = map.map((row) => row.map((cell) => ({ ...cell }))); // 深拷贝赋值
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  public setPlayerPosition(x: number, y: number): void { // 外部接口用于移动玩家
+    this.playerContainer.setPosition(x, y); // 设置位置
+    this.updatePlayerDepth(); // 更新深度
+  } // 方法结束
+} // 类结束

--- a/miniWorld/src/systems/Inventory.ts
+++ b/miniWorld/src/systems/Inventory.ts
@@ -1,0 +1,45 @@
+export interface Item { id: string; name: string; count: number; } // 定义物品结构
+// 分隔注释 // 保持行有注释
+export class Inventory { // 定义背包类
+  private items: Map<string, Item>; // 使用Map保存物品
+  // 分隔注释 // 保持行有注释
+  public constructor() { // 构造函数
+    this.items = new Map(); // 初始化Map
+  } // 构造结束
+  // 分隔注释 // 保持行有注释
+  public add(id: string, name: string, delta: number): void { // 增加或减少物品数量
+    const current = this.items.get(id); // 获取当前物品
+    if (current) { // 如果存在
+      const nextCount = Math.max(0, current.count + delta); // 计算新的数量并防止负数
+      this.items.set(id, { id, name: current.name, count: nextCount }); // 更新物品数量
+    } else { // 如果不存在
+      this.items.set(id, { id, name, count: Math.max(0, delta) }); // 创建新物品并防止负数
+    } // 条件结束
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  public getAll(): Item[] { // 获取所有物品列表
+    return Array.from(this.items.values()).map((item) => ({ ...item })); // 返回浅拷贝数组
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  public has(id: string, count: number): boolean { // 判断是否拥有指定数量
+    const item = this.items.get(id); // 获取物品
+    return item !== undefined && item.count >= count; // 返回是否满足数量
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  public toJSON(): { items: Item[] } { // 序列化背包
+    return { items: this.getAll() }; // 返回物品数组包装
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  public loadFromJSON(json: { items: Item[] }): void { // 将JSON数据载入背包
+    this.items.clear(); // 清空当前数据
+    json.items.forEach((item) => { // 遍历序列化物品
+      this.items.set(item.id, { ...item }); // 逐条写入Map
+    }); // 遍历结束
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  public static fromJSON(json: { items: Item[] }): Inventory { // 反序列化背包
+    const inventory = new Inventory(); // 创建新实例
+    inventory.loadFromJSON(json); // 使用载入方法恢复数据
+    return inventory; // 返回实例
+  } // 方法结束
+} // 类结束

--- a/miniWorld/src/test/Inventory.spec.ts
+++ b/miniWorld/src/test/Inventory.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'; // 引入测试函数
+import { Inventory } from '../systems/Inventory'; // 引入背包类
+// 分隔注释 // 保持行有注释
+describe('Inventory', () => { // 描述背包测试
+  it('合并数量并支持序列化往返', () => { // 定义测试用例
+    const bag = new Inventory(); // 创建背包
+    bag.add('wood', '木头', 1); // 添加一次物品
+    bag.add('wood', '木头', 2); // 再次添加同物品
+    const items = bag.getAll(); // 获取物品列表
+    expect(items[0]?.count).toBe(3); // 断言数量合并
+    expect(bag.has('wood', 3)).toBe(true); // 断言查询数量
+    const json = bag.toJSON(); // 序列化背包
+    const restored = Inventory.fromJSON(json); // 反序列化背包
+    expect(restored.has('wood', 3)).toBe(true); // 断言往返一致
+  }); // 用例结束
+}); // 描述结束

--- a/miniWorld/src/test/SaveLoad.spec.ts
+++ b/miniWorld/src/test/SaveLoad.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from 'vitest'; // 引入测试工具
+import { __setStorage, save, load } from '../systems/SaveLoad'; // 引入存档函数
+// 分隔注释 // 保持行有注释
+const memory = new Map<string, unknown>(); // 创建内存存储
+// 分隔注释 // 保持行有注释
+const fakeStorage = { // 构造localforage替身
+  async setItem(key: string, value: unknown) { memory.set(key, value); return value; }, // 实现写入
+  async getItem(key: string) { return memory.has(key) ? memory.get(key) : null; }, // 实现读取
+  async removeItem(key: string) { memory.delete(key); }, // 实现删除
+  async clear() { memory.clear(); }, // 实现清空
+  async length() { return memory.size; }, // 返回长度
+  async key(index: number) { return Array.from(memory.keys())[index] ?? null; }, // 返回键名
+  async keys() { return Array.from(memory.keys()); }, // 返回全部键
+  async iterate<T>(iterator: (value: unknown, key: string, iterationNumber: number) => T | undefined) { // 实现遍历
+    let iteration = 0; // 初始化计数
+    for (const [key, value] of memory.entries()) { // 遍历键值
+      const result = iterator(value, key, iteration); // 执行回调
+      iteration += 1; // 累加计数
+      if (result !== undefined) { // 如果回调返回值
+        return result; // 返回回调结果
+      } // 条件结束
+    } // 循环结束
+    return undefined; // 默认返回
+  }, // 结束iterate
+}; // 替身对象结束
+// 分隔注释 // 保持行有注释
+beforeEach(() => { // 每个用例前执行
+  memory.clear(); // 清空内存
+  __setStorage(fakeStorage as unknown as any); // 替换存储实例
+}); // 结束beforeEach
+// 分隔注释 // 保持行有注释
+describe('SaveLoad', () => { // 描述存档测试
+  it('保存并读取相同对象', async () => { // 定义测试用例
+    const state = { bag: [{ id: 'wood', count: 3 }] }; // 构造状态
+    await save('slot', state); // 保存状态
+    const restored = await load('slot'); // 读取状态
+    expect(restored).toEqual(state); // 断言读取结果
+  }); // 用例结束
+}); // 描述结束

--- a/miniWorld/src/test/TileRules.spec.ts
+++ b/miniWorld/src/test/TileRules.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'; // 引入测试工具
+import { genDemoMap, isWalkable, layerOf } from '../world/TileRules'; // 引入地图函数
+import { TileCell } from '../world/Types'; // 引入类型
+// 分隔注释 // 保持行有注释
+describe('TileRules', () => { // 描述地图规则测试
+  it('生成地图并正确区分通行', () => { // 定义测试用例
+    const map = genDemoMap(10, 10); // 生成示例地图
+    expect(isWalkable(map[5][0])).toBe(true); // 道路可行走
+    expect(isWalkable(map[2][2])).toBe(false); // 水域不可行走
+    expect(isWalkable(map[4][4])).toBe(false); // 墙体不可行走
+  }); // 用例结束
+  it('overpass 层级返回正确', () => { // 定义层级测试
+    const cell: TileCell = { type: 'TILE_FLOOR', layerTag: 'overpass' }; // 构造桥面单元
+    expect(layerOf(cell)).toBe('overpass'); // 断言层位
+  }); // 用例结束
+}); // 描述结束

--- a/miniWorld/src/ui/LabelManager.ts
+++ b/miniWorld/src/ui/LabelManager.ts
@@ -1,0 +1,24 @@
+import Phaser from 'phaser'; // 引入Phaser框架
+// 分隔注释 // 保持行有注释
+export class LabelManager { // 定义提示标签管理器
+  private scene: Phaser.Scene; // 保存场景引用
+  private hints: Phaser.GameObjects.Text[]; // 保存当前提示列表
+  // 分隔注释 // 保持行有注释
+  public constructor(scene: Phaser.Scene) { // 构造函数
+    this.scene = scene; // 保存场景
+    this.hints = []; // 初始化提示数组
+  } // 构造结束
+  // 分隔注释 // 保持行有注释
+  public showHintAt(worldX: number, worldY: number, text: string): void { // 在指定位置显示提示
+    this.hideAll(); // 先移除旧提示
+    const hint = this.scene.add.text(worldX, worldY, text, { fontFamily: 'sans-serif', fontSize: '12px', color: '#ffff66', backgroundColor: 'rgba(0,0,0,0.66)', padding: { x: 4, y: 2 } }); // 创建提示文本
+    hint.setOrigin(0.5, 1); // 设置锚点
+    hint.setDepth(1000); // 确保渲染在上层
+    this.hints.push(hint); // 保存提示引用
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  public hideAll(): void { // 隐藏所有提示
+    this.hints.forEach((hint) => hint.destroy()); // 销毁提示
+    this.hints = []; // 清空数组
+  } // 方法结束
+} // 类结束

--- a/miniWorld/src/ui/PopupManager.ts
+++ b/miniWorld/src/ui/PopupManager.ts
@@ -1,0 +1,36 @@
+import Phaser from 'phaser'; // 引入Phaser框架
+// 分隔注释 // 保持行有注释
+interface PopupEntry { text: Phaser.GameObjects.Text; life: number; velocity: number; } // 定义飘字条目
+// 分隔注释 // 保持行有注释
+export class PopupManager { // 定义飘字管理器
+  private scene: Phaser.Scene; // 保存场景引用
+  private entries: PopupEntry[]; // 保存飘字数组
+  // 分隔注释 // 保持行有注释
+  public constructor(scene: Phaser.Scene) { // 构造函数
+    this.scene = scene; // 保存场景
+    this.entries = []; // 初始化数组
+  } // 构造结束
+  // 分隔注释 // 保持行有注释
+  public popup(worldX: number, worldY: number, text: string, color = '#ffffff'): void { // 产生飘字
+    const label = this.scene.add.text(worldX, worldY, text, { fontFamily: 'sans-serif', fontSize: '12px', color, stroke: '#000000', strokeThickness: 2 }); // 创建文字对象
+    label.setOrigin(0.5, 1); // 设置锚点
+    label.setDepth(1100); // 提升层级
+    this.entries.push({ text: label, life: 1000, velocity: 40 }); // 将飘字加入数组
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  public update(delta: number): void { // 更新飘字动画
+    const remain: PopupEntry[] = []; // 初始化剩余数组
+    this.entries.forEach((entry) => { // 遍历飘字
+      const progress = delta; // 记录本帧增量
+      entry.life -= progress; // 减少寿命
+      entry.text.y -= (entry.velocity * progress) / 1000; // 向上移动
+      entry.text.alpha = Math.max(0, entry.life / 1000); // 根据寿命调整透明度
+      if (entry.life > 0) { // 如果仍然存活
+        remain.push(entry); // 保留条目
+      } else { // 否则
+        entry.text.destroy(); // 销毁文字
+      } // 条件结束
+    }); // 遍历结束
+    this.entries = remain; // 更新数组
+  } // 方法结束
+} // 类结束

--- a/miniWorld/src/world/Nodes.ts
+++ b/miniWorld/src/world/Nodes.ts
@@ -1,0 +1,26 @@
+import { GridPos } from './Types'; // 引入网格坐标类型
+// 分隔注释 // 保持行有注释
+export type ResourceNodeType = 'TREE' | 'ROCK' | 'FLOWER'; // 定义资源节点类型
+export interface ResourceNode { pos: GridPos; type: ResourceNodeType; loot: { id: string; name: string; count: number }; } // 定义资源节点结构
+// 分隔注释 // 保持行有注释
+let resourceNodes: ResourceNode[] = [ // 初始化资源节点数组
+  { pos: { x: 7, y: 2 }, type: 'TREE', loot: { id: 'wood', name: '木头', count: 1 } }, // 树节点示例
+  { pos: { x: 4, y: 6 }, type: 'ROCK', loot: { id: 'stone', name: '石头', count: 1 } }, // 岩石节点示例
+  { pos: { x: 8, y: 3 }, type: 'FLOWER', loot: { id: 'flower', name: '花朵', count: 1 } }, // 花朵节点示例
+]; // 数组结束
+// 分隔注释 // 保持行有注释
+export function getAllNodes(): ResourceNode[] { // 导出获取全部节点的函数
+  return resourceNodes.map((node) => ({ ...node, pos: { ...node.pos }, loot: { ...node.loot } })); // 返回深拷贝以避免外部修改
+} // 函数结束
+// 分隔注释 // 保持行有注释
+export function setAllNodes(nodes: ResourceNode[]): void { // 导出重置节点数组的函数
+  resourceNodes = nodes.map((node) => ({ pos: { ...node.pos }, type: node.type, loot: { ...node.loot } })); // 深拷贝赋值
+} // 函数结束
+// 分隔注释 // 保持行有注释
+export function getNodeAt(pos: GridPos): ResourceNode | undefined { // 根据坐标查找节点
+  return resourceNodes.find((node) => node.pos.x === pos.x && node.pos.y === pos.y); // 查找匹配节点
+} // 函数结束
+// 分隔注释 // 保持行有注释
+export function removeNodeAt(pos: GridPos): void { // 根据坐标移除节点
+  resourceNodes = resourceNodes.filter((node) => !(node.pos.x === pos.x && node.pos.y === pos.y)); // 过滤掉命中节点
+} // 函数结束

--- a/miniWorld/src/world/TileRules.ts
+++ b/miniWorld/src/world/TileRules.ts
@@ -1,0 +1,37 @@
+import { TileCell, TileType } from './Types'; // 引入类型定义
+// 分隔注释 // 保持行有注释
+const WALKABLE_TYPES: TileType[] = ['GRASS', 'ROAD', 'TILE_FLOOR']; // 定义可通行地形集合
+// 分隔注释 // 保持行有注释
+export function genDemoMap(width: number, height: number): TileCell[][] { // 生成演示地图
+  const map: TileCell[][] = []; // 初始化地图数组
+  for (let y = 0; y < height; y += 1) { // 遍历行
+    const row: TileCell[] = []; // 初始化当前行
+    for (let x = 0; x < width; x += 1) { // 遍历列
+      row.push({ type: 'GRASS', layerTag: 'ground' }); // 默认填充草地
+    } // 列循环结束
+    map.push(row); // 将行加入地图
+  } // 行循环结束
+  for (let x = 0; x < width; x += 1) { // 构建道路
+    map[5][x] = { type: 'ROAD', layerTag: 'ground' }; // 设置水平道路
+  } // 道路循环结束
+  for (let y = 2; y < 5; y += 1) { // 构建水域
+    map[y][2] = { type: 'WATER', layerTag: 'ground' }; // 设置河流单元
+    map[y][3] = { type: 'LAKE', layerTag: 'ground' }; // 设置湖泊单元
+  } // 水域循环结束
+  map[7][7] = { type: 'HOUSE', layerTag: 'ground' }; // 放置房屋
+  map[2][7] = { type: 'TREE', layerTag: 'ground' }; // 放置树木
+  map[6][4] = { type: 'ROCK', layerTag: 'ground' }; // 放置岩石
+  map[3][8] = { type: 'LAVA', layerTag: 'ground' }; // 放置岩浆
+  map[4][4] = { type: 'WALL', layerTag: 'ground' }; // 放置墙体
+  map[4][5] = { type: 'TILE_FLOOR', layerTag: 'overpass' }; // 设置可穿越的桥
+  map[4][6] = { type: 'TILE_FLOOR', layerTag: 'overpass' }; // 桥的延伸
+  return map; // 返回生成的地图
+} // 函数结束
+// 分隔注释 // 保持行有注释
+export function isWalkable(cell: TileCell): boolean { // 判断单元格是否可走
+  return WALKABLE_TYPES.includes(cell.type); // 根据可通行集合判断
+} // 函数结束
+// 分隔注释 // 保持行有注释
+export function layerOf(cell: TileCell): 'ground' | 'overpass' { // 获取单元格层位
+  return cell.layerTag ?? 'ground'; // 默认返回地面层
+} // 函数结束

--- a/miniWorld/src/world/Types.ts
+++ b/miniWorld/src/world/Types.ts
@@ -1,0 +1,3 @@
+export type TileType = 'GRASS' | 'ROAD' | 'TILE_FLOOR' | 'WATER' | 'LAKE' | 'WALL' | 'TREE' | 'HOUSE' | 'ROCK' | 'LAVA'; // 定义地形类型联合类型
+export interface GridPos { x: number; y: number; } // 定义网格坐标接口
+export interface TileCell { type: TileType; layerTag?: 'ground' | 'overpass'; } // 定义单元格数据结构

--- a/miniWorld/tsconfig.json
+++ b/miniWorld/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "lib": ["ESNext", "DOM"],
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/miniWorld/vite.config.ts
+++ b/miniWorld/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite'; // 引入定义配置函数
+import path from 'path'; // 引入路径工具
+// 分隔注释 // 保持行有注释
+export default defineConfig({ // 导出Vite配置对象
+  root: path.resolve(__dirname), // 设置项目根目录
+  publicDir: path.resolve(__dirname, 'assets_external'), // 指定外部素材目录为公共目录
+  server: { // 开发服务器配置对象
+    host: true, // 允许外部访问
+  }, // 结束服务器配置
+  build: { // 构建相关配置
+    outDir: 'dist', // 指定输出目录
+    emptyOutDir: true, // 构建前清空目录
+  }, // 结束构建配置
+}); // 结束配置导出


### PR DESCRIPTION
## Summary
- add the MiniWorld Vite + Phaser scaffold with BootScene and a world exploration loop, including pixel HUD and input handling
- implement the unified loader with runtime placeholder textures and external asset overrides, plus inventory/save systems and UI helpers
- document run instructions, control scheme, and data structures, and cover inventory/tile rules/save-load logic with vitest

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e75216eb408328b2cfe0b9c48ba036