### PR TITLE
Implement user asset import and preview pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: miniworld-dev miniworld-build miniworld-test user-import user-preview build-all
+.PHONY: miniworld-dev miniworld-build miniworld-test user-import user-import-move user-import-rules user-preview build-all
 
 miniworld-dev:
 	pnpm --filter miniworld dev
@@ -11,6 +11,12 @@ miniworld-test:
 
 user-import:
 	python3 scripts/import_user_assets.py
+
+user-import-move:
+	python3 scripts/import_user_assets.py --move
+
+user-import-rules:
+	python3 scripts/import_user_assets.py --rules assets/mapping/import_rules.json
 
 user-preview:
 	python3 scripts/preview_user_assets.py

--- a/assets/build/asset_index.json
+++ b/assets/build/asset_index.json
@@ -1,4 +1,0 @@
-{
-  "generatedAt": "",
-  "files": []
-}

--- a/assets/preview_index.json
+++ b/assets/preview_index.json
@@ -1,1 +1,3278 @@
-{}
+{
+  "audio": [
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Battle9.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm11戦闘プレジデント・宝条.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Field4.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm15Hお使い.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Scene4.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Town1.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm13H客.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Theme2.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm09戦闘雑魚.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm17Hクラウド.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Battle2.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Battle3.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Battle7.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Battle6.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Town3.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Scene2.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm02ステージ七番街スラム.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Battle5.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Dungeon1.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Dungeon8.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Dungeon3.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm05ステージ神羅飛空艇.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Field1.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm07ステージ神羅ビル.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Scene6.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Dungeon7.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm12戦闘セフィロス.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Dungeon4.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Dungeon6.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Battle1.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Theme4.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm03ステージウォールマーケット.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm06ステージコレルプリズン.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm08ステージ神羅屋敷.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Theme1.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Town2.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Ship.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm16H敗北.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Battle8.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm04ステージ弐番魔晄炉.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Dungeon5.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Field3.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Town5.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Town4.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Field2.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Scene1.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Town6.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm14H仲間.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm10戦闘中ボス.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Dungeon2.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Town7.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Battle4.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Theme5.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/bgm01ステージセブンスヘブン.mp3"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Airship.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Theme3.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Scene3.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Dungeon9.ogg"
+    },
+    {
+      "type": "bgm",
+      "path": "assets/build/audio/bgm/Scene5.ogg"
+    },
+    {
+      "type": "bgs",
+      "path": "assets/build/audio/bgs/Quake.ogg"
+    },
+    {
+      "type": "bgs",
+      "path": "assets/build/audio/bgs/Sea.ogg"
+    },
+    {
+      "type": "bgs",
+      "path": "assets/build/audio/bgs/Rain.ogg"
+    },
+    {
+      "type": "bgs",
+      "path": "assets/build/audio/bgs/Darkness.ogg"
+    },
+    {
+      "type": "bgs",
+      "path": "assets/build/audio/bgs/Drips.ogg"
+    },
+    {
+      "type": "bgs",
+      "path": "assets/build/audio/bgs/Storm.ogg"
+    },
+    {
+      "type": "bgs",
+      "path": "assets/build/audio/bgs/Fire.ogg"
+    },
+    {
+      "type": "bgs",
+      "path": "assets/build/audio/bgs/Wind.ogg"
+    },
+    {
+      "type": "bgs",
+      "path": "assets/build/audio/bgs/River.ogg"
+    },
+    {
+      "type": "bgs",
+      "path": "assets/build/audio/bgs/Clock.ogg"
+    },
+    {
+      "type": "me",
+      "path": "assets/build/audio/me/Gameover1.ogg"
+    },
+    {
+      "type": "me",
+      "path": "assets/build/audio/me/Item.ogg"
+    },
+    {
+      "type": "me",
+      "path": "assets/build/audio/me/Organ.ogg"
+    },
+    {
+      "type": "me",
+      "path": "assets/build/audio/me/Gameover2.ogg"
+    },
+    {
+      "type": "me",
+      "path": "assets/build/audio/me/Fanfare3.ogg"
+    },
+    {
+      "type": "me",
+      "path": "assets/build/audio/me/Mystery.ogg"
+    },
+    {
+      "type": "me",
+      "path": "assets/build/audio/me/Victory2.ogg"
+    },
+    {
+      "type": "me",
+      "path": "assets/build/audio/me/Inn.ogg"
+    },
+    {
+      "type": "me",
+      "path": "assets/build/audio/me/Fanfare1.ogg"
+    },
+    {
+      "type": "me",
+      "path": "assets/build/audio/me/Shock.ogg"
+    },
+    {
+      "type": "me",
+      "path": "assets/build/audio/me/Fanfare2.ogg"
+    },
+    {
+      "type": "me",
+      "path": "assets/build/audio/me/Victory1.ogg"
+    },
+    {
+      "type": "me",
+      "path": "assets/build/audio/me/Gag.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv31.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Dog.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Earth3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv58.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv19.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Sword5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Barrier.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Explosion5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Blow8.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Shot2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Thunder7.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Skill3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Thunder5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv57.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Cow.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Water1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Raise3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Scream.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Saint7.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Raise1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv47.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Switch3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Blow6.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Chest.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Crow.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Ice4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv35.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Explosion2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Ice6.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/ミッションクリア.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv59.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Absorb1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv03.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Blow2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv05.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Buzzer1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Powerup.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Bow3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Save.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Decision1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Attack3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Applause2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Monster6.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv21.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv07.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Buzzer2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Explosion4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Battle2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Ice9.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Damage1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Sound1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv13.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Battle3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Heal6.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Close1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Item2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Sword1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv44.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Slash5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Fire1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Damage5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Paralyze3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Earth7.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Saint9.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Open2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Earth2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Explosion1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Collapse4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Darkness3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Water6.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Sleep.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Monster1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Saint4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Thunder8.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv01.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Collapse1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Wind11.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/宝箱.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Wind10.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Slash2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Decision3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv42.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Down1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv18.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Attack1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv38.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Saint1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv50.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Magic5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Thunder9.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv48.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Sound2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Fire5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Up2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Book2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Poison.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Earth8.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Open5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Shop.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Teleport.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv54.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Ice2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Darkness5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Fall.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Disappointment.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Dive.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Crash.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Heal1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv64.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv52.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Bell1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Slash10.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Phone.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Darkness4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Ice10.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv10.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Jump2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Chime1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Sheep.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Shot1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Noise.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv56.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Bell2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Attack2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Explosion6.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Thunder11.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Slash11.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv45.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Blow4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Paralyze2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Slash7.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Magic4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Close3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Book1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Switch1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Switch2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Close2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Earth9.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Saint6.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Ice8.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Slash3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Saint5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Break.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Thunder2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Down3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Up3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Water4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Machine.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Fire6.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Shot3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Flash3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Water3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Thunder3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Fire3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv60.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Jump1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv37.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Earth4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Fire7.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Saint8.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Starlight.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Fire8.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Thunder10.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Hammer.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Magic1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Sand.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv20.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Autodoor.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Stare.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Magic6.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Equip1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Knock.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Saint2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Explosion7.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Darkness1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Run.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv51.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Fire4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv24.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Up4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Blow5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Darkness8.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Wind4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv33.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Blow7.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Darkness6.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Water5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Darkness2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Chime2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Devil2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Gun2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Reflection.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Battle1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv30.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Confuse.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv29.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Slash1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Wind6.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Sound3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Thunder12.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Bell3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Damage4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv43.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv25.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Parry.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Monster7.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Ice5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Slash9.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Paralyze1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Sword2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Sword3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Chicken.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv34.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Slash12.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Devil1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Resonance.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Damage3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv40.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Decision2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Push.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv08.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Wind7.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Heal2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Equip2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Earth5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Cry1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Ice3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Item1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Bow1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Evasion2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Thunder1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Wind2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv32.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Gun1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Skill1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Open3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Down2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Fire9.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Breath.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv28.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Darkness7.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Heal7.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Wind3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Sword4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Up1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Bite.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Pollen.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Blind.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Cancel1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Earth1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv55.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv46.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Cry2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv09.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv16.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv41.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Thunder4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Wind8.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Devil3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv49.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv15.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Thunder6.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Skill2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv26.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv27.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv22.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Down4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Laser.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Evasion1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Saint3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Heal3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Fog1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Load.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Raise2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Ice7.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv36.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Bow2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Wind5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Magic2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Cancel2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Move.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Silence.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Key.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Coin.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Earth6.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Crossbow.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Fire2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Wind1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Collapse3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Ice11.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Blow3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Magic3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Wind9.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Cursor2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv04.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv23.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Cat.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Heal5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Slash4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Miss.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv11.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Horse.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Flash1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Open1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Explosion3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Magic7.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Blow1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Item3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Cursor1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv14.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Flash2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Monster5.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Collapse2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv39.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv17.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Absorb2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Slash6.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Monster2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Fog2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Applause1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv53.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Damage2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Ice1.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Open4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv12.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv06.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Equip3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Monster4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Recovery.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Bow4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Slash8.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Heal4.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Monster3.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Water2.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/cv02.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Twine.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Frog.ogg"
+    },
+    {
+      "type": "se",
+      "path": "assets/build/audio/se/Wolf.ogg"
+    }
+  ],
+  "images": [
+    {
+      "type": "characters",
+      "path": "assets/build/characters/!$Gate2.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Animal.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/People1.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/!Switch1.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Vehicle.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Monster1.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/$BigMonster2.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/People3.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/$BigMonster1.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Actor3.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Actor4.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/People4.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/!Other2.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Evil.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/People5.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Monster2.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Actor5.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/People8.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Behavior3.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Actor1.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Riding.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Damage3.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/People2.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/!Door3.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/!Switch2.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/$Coffin.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Spiritual.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/!Door2.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Damage1.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/!Door1.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/!Crystal.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Insane2.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Insane1.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Damage4.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Behavior1.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/People7.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Monster3.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Behavior4.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Actor2.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/!Flame.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/People6.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Behavior2.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/!Other3.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/!Hexagram.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/!Chest.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/!Other1.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/!$Gate1.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Damage2.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Assassin.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Evilgod.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Grappler_m.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Spider.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Asura.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Warrior_f.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Soldier.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Dragon.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Sahagin.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Wizard_m.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Gargoyle.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Snake.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Willowisp.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Angel.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Imp.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Mimic.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Plant.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Chimera.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Windspirit.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Swordman.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Thief_f.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Thief_m.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Kerberos.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Mage.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Garuda.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Bandit.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Behemoth.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Gayzer.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Werewolf.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Evilking.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Wizard_f.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Death.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Ogre.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Vampire.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Hornet.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Grappler_f.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Ifrit.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Lamia.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Ghost.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Rat.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Fanatic.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Cleric_f.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Firespirit.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Puppet.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Slime.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Fairy.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Zombie.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Hero_m.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/General.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Captain.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Goddess.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Earthspirit.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Icelady.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/God.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Paladin_f.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Warrior_m.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Hero_f.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Succubus.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Delf_f.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Delf_m.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Orc.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Darklord.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Cockatrice.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Minotaur.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Rogue.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Cleric_m.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Waterspirit.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Bat.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Skeleton.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Priest.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Scorpion.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Jellyfish.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Paladin_m.png"
+    },
+    {
+      "type": "characters",
+      "path": "assets/build/characters/Demon.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Mountains4.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/CloudySky1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Mountains2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Ocean2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Mountains5.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/BlueSky.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Mountains3.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/DarkSpace2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/CloudySky2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Mountains1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Ocean1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Sunset.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/SeaofClouds.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/DarkSpace1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/StarlitSky.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Dungeon_A1.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Inside_A4.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Inside_C.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Outside_A3.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Dungeon_C.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Dungeon_B.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Outside_A2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Outside_B.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Dungeon_B.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Outside_A2.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/World_A2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Dungeon_A5.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Inside_A1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Outside_A5.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Inside_A2.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Dungeon_A4.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/World_A2.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Dungeon_C.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Outside_A4.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/World_B.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Inside_A5.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Outside_A3.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Dungeon_A2.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Inside_A2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Dungeon_A4.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Inside_B.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Dungeon_A1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Inside_C.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/World_A1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Outside_A1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Outside_A1.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Dungeon_A2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Outside_B.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Outside_C.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/World_B.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Inside_A1.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/World_A1.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Dungeon_A5.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Outside_A5.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Inside_A5.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Outside_C.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Inside_A4.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Inside_B.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Outside_A4.txt"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Ruins1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/RockCave2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/DirtField.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Paved.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Road1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/PoisonSwamp.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/DemonicWorld1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/DemonicWorld2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Stone1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/RockCave1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Stone3.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Factory1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/DirtCave.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Lava2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Stone2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Clouds.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/DarkSpace.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Cobblestones4.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Castle.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Translucent.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Snowfield.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Ship.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Road2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Wasteland.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Factory2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Sky.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/DecorativeTile.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Dirt1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Crystal2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Meadow.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Cobblestones1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Dirt2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Road3.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Crystal1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/IceMaze.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/IceCave.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Ruins2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Fort.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/WireMesh.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Sand.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/DemonCastle.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Tent.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Cobblestones2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Grassland.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/LavaCave.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Ruins3.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Wood2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/GrassMaze.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Snow.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Lava1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/InBody.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Desert.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Cobblestones3.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Wood1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/DemonCastle2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Castle1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Forest1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Crystal.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/RockCave.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Fort2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Fort1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Room2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Stone5.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Tower.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/DemonicWorld.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Port.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Castle2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Town4.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Sea.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Factory.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Brick.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Mine.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Town5.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Castle3.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Town2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Town3.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Forest2.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Ruins.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Lava.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Town1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Temple.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Stone4.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Room4.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Room1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/DemonCastle3.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Room3.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Bridge.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/DemonCastle1.png"
+    },
+    {
+      "type": "tiles",
+      "path": "assets/build/tiles/Cliff.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Water1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Light3.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Ice5.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special4.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Death1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Gun2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Light6.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Darkness2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Wind1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Fire3.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Blow1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Heal3.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special15.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Water2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Heal1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Thunder4.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/State4.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Sword3.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Attack10.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Sword5.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special6.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Light2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Attack7.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Thunder2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Heal5.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Sword1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Spear3.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Attack1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Fire1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/State5.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/State3.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Attack2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Thunder3.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special3.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Attack4.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Sword2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Attack8.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Ice4.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/State6.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special10.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Fire2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Attack6.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Attack11.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Spear2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Gun1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Fire4.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Earth1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Blow2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Attack5.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/State2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Attack9.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Heal6.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Light4.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Heal2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/State1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Attack12.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Earth2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Light1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special16.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special13.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Sword6.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Heal4.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special14.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Spear1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Ice3.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Wind3.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special8.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Water3.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Meteor.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Attack3.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special9.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special12.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Earth3.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Sword10.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Light7.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Ice1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special17.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Wind2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special11.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Darkness1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Sword7.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Sword8.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special7.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Darkness3.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Thunder1.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Sword4.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Blow3.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Light5.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Sword9.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Ice2.png"
+    },
+    {
+      "type": "effects",
+      "path": "assets/build/effects/Special5.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Shadow.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/IconSet.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/BattleStart.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Window.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Balloon.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/GameOver.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Tower2.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Universe.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Dragon.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Crystal.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Island.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Devil.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Tower1.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/CrossedSwords.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Gates.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Castle.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Night.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Sword.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Hexagram.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Book.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Volcano.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Fountain.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Plain.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/DemonCastle.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/World.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/WorldMap.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Dragons.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Fire.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Heroes.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Mountains.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Gargoyles.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Forest.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Mist.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Metal.png"
+    },
+    {
+      "type": "ui",
+      "path": "assets/build/ui/Leaves.png"
+    }
+  ]
+}

--- a/logs/user_imports.log
+++ b/logs/user_imports.log
@@ -2,3 +2,2568 @@
 [2025-10-11 10:53:55,225] INFO import completed | audio=420, characters=134, effects=93, readme.md=1, tiles=167, ui=35, user_manifest.json=1
 [2025-10-11 10:54:00,577] INFO preview start | build=/workspace/PixelWorld/assets/build
 [2025-10-11 10:54:00,647] INFO preview completed | /workspace/PixelWorld/assets/build/preview_index.json generated (853 files)
+[INFO] Start import (copy mode). Rules = default
+[ERROR] 路径缺少分类信息: README.md
+[ERROR] 路径缺少分类信息: user_manifest.json
+[WARN] 未匹配的目录 characters/main/!$Gate2.png 已跳过
+[WARN] 未匹配的目录 characters/main/Animal.png 已跳过
+[WARN] 未匹配的目录 characters/main/People1.png 已跳过
+[WARN] 未匹配的目录 characters/main/!Switch1.png 已跳过
+[WARN] 未匹配的目录 characters/main/Vehicle.png 已跳过
+[WARN] 未匹配的目录 characters/main/Monster1.png 已跳过
+[WARN] 未匹配的目录 characters/main/$BigMonster2.png 已跳过
+[WARN] 未匹配的目录 characters/main/People3.png 已跳过
+[WARN] 未匹配的目录 characters/main/$BigMonster1.png 已跳过
+[WARN] 未匹配的目录 characters/main/Actor3.png 已跳过
+[WARN] 未匹配的目录 characters/main/Actor4.png 已跳过
+[WARN] 未匹配的目录 characters/main/People4.png 已跳过
+[WARN] 未匹配的目录 characters/main/!Other2.png 已跳过
+[WARN] 未匹配的目录 characters/main/Evil.png 已跳过
+[WARN] 未匹配的目录 characters/main/People5.png 已跳过
+[WARN] 未匹配的目录 characters/main/Monster2.png 已跳过
+[WARN] 未匹配的目录 characters/main/Actor5.png 已跳过
+[WARN] 未匹配的目录 characters/main/People8.png 已跳过
+[WARN] 未匹配的目录 characters/main/Behavior3.png 已跳过
+[WARN] 未匹配的目录 characters/main/Actor1.png 已跳过
+[WARN] 未匹配的目录 characters/main/Riding.png 已跳过
+[WARN] 未匹配的目录 characters/main/Damage3.png 已跳过
+[WARN] 未匹配的目录 characters/main/People2.png 已跳过
+[WARN] 未匹配的目录 characters/main/!Door3.png 已跳过
+[WARN] 未匹配的目录 characters/main/!Switch2.png 已跳过
+[WARN] 未匹配的目录 characters/main/$Coffin.png 已跳过
+[WARN] 未匹配的目录 characters/main/Spiritual.png 已跳过
+[WARN] 未匹配的目录 characters/main/!Door2.png 已跳过
+[WARN] 未匹配的目录 characters/main/Damage1.png 已跳过
+[WARN] 未匹配的目录 characters/main/!Door1.png 已跳过
+[WARN] 未匹配的目录 characters/main/!Crystal.png 已跳过
+[WARN] 未匹配的目录 characters/main/Insane2.png 已跳过
+[WARN] 未匹配的目录 characters/main/Insane1.png 已跳过
+[WARN] 未匹配的目录 characters/main/Damage4.png 已跳过
+[WARN] 未匹配的目录 characters/main/Behavior1.png 已跳过
+[WARN] 未匹配的目录 characters/main/People7.png 已跳过
+[WARN] 未匹配的目录 characters/main/Monster3.png 已跳过
+[WARN] 未匹配的目录 characters/main/Behavior4.png 已跳过
+[WARN] 未匹配的目录 characters/main/Actor2.png 已跳过
+[WARN] 未匹配的目录 characters/main/!Flame.png 已跳过
+[WARN] 未匹配的目录 characters/main/People6.png 已跳过
+[WARN] 未匹配的目录 characters/main/Behavior2.png 已跳过
+[WARN] 未匹配的目录 characters/main/!Other3.png 已跳过
+[WARN] 未匹配的目录 characters/main/!Hexagram.png 已跳过
+[WARN] 未匹配的目录 characters/main/!Chest.png 已跳过
+[WARN] 未匹配的目录 characters/main/!Other1.png 已跳过
+[WARN] 未匹配的目录 characters/main/!$Gate1.png 已跳过
+[WARN] 未匹配的目录 characters/main/Damage2.png 已跳过
+[WARN] 未匹配的目录 characters/faces/People1.png 已跳过
+[WARN] 未匹配的目录 characters/faces/Monster1.png 已跳过
+[WARN] 未匹配的目录 characters/faces/People3.png 已跳过
+[WARN] 未匹配的目录 characters/faces/Actor3.png 已跳过
+[WARN] 未匹配的目录 characters/faces/Actor4.png 已跳过
+[WARN] 未匹配的目录 characters/faces/People4.png 已跳过
+[WARN] 未匹配的目录 characters/faces/Evil.png 已跳过
+[WARN] 未匹配的目录 characters/faces/Actor5.png 已跳过
+[WARN] 未匹配的目录 characters/faces/Actor1.png 已跳过
+[WARN] 未匹配的目录 characters/faces/People2.png 已跳过
+[WARN] 未匹配的目录 characters/faces/Spiritual.png 已跳过
+[WARN] 未匹配的目录 characters/faces/Actor2.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Assassin.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Evilgod.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Grappler_m.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Spider.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Asura.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Warrior_f.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Soldier.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Dragon.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Sahagin.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Wizard_m.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Gargoyle.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Snake.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Willowisp.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Angel.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Imp.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Mimic.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Plant.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Chimera.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Windspirit.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Swordman.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Thief_f.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Thief_m.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Kerberos.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Mage.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Garuda.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Bandit.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Behemoth.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Gayzer.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Werewolf.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Evilking.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Wizard_f.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Death.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Ogre.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Vampire.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Hornet.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Grappler_f.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Ifrit.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Lamia.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Ghost.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Rat.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Fanatic.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Cleric_f.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Firespirit.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Puppet.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Slime.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Fairy.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Zombie.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Hero_m.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/General.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Captain.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Goddess.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Earthspirit.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Icelady.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/God.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Paladin_f.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Warrior_m.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Hero_f.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Succubus.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Delf_f.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Delf_m.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Orc.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Darklord.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Cockatrice.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Minotaur.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Rogue.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Cleric_m.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Waterspirit.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Bat.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Skeleton.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Priest.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Scorpion.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Jellyfish.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Paladin_m.png 已跳过
+[WARN] 未匹配的目录 characters/battlers/Demon.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Water1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Light3.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Ice5.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special4.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Death1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Gun2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Light6.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Darkness2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Wind1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Fire3.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Blow1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Heal3.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special15.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Water2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Heal1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Thunder4.png 已跳过
+[WARN] 未匹配的目录 effects/animations/State4.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Sword3.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Attack10.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Sword5.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special6.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Light2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Attack7.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Thunder2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Heal5.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Sword1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Spear3.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Attack1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Fire1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/State5.png 已跳过
+[WARN] 未匹配的目录 effects/animations/State3.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Attack2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Thunder3.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special3.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Attack4.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Sword2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Attack8.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Ice4.png 已跳过
+[WARN] 未匹配的目录 effects/animations/State6.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special10.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Fire2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Attack6.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Attack11.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Spear2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Gun1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Fire4.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Earth1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Blow2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Attack5.png 已跳过
+[WARN] 未匹配的目录 effects/animations/State2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Attack9.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Heal6.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Light4.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Heal2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/State1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Attack12.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Earth2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Light1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special16.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special13.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Sword6.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Heal4.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special14.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Spear1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Ice3.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Wind3.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special8.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Water3.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Meteor.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Attack3.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special9.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special12.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Earth3.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Sword10.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Light7.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Ice1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special17.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Wind2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special11.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Darkness1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Sword7.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Sword8.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special7.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Darkness3.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Thunder1.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Sword4.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Blow3.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Light5.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Sword9.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Ice2.png 已跳过
+[WARN] 未匹配的目录 effects/animations/Special5.png 已跳过
+[WARN] 未匹配的目录 tiles/parallaxes/Mountains4.png 已跳过
+[WARN] 未匹配的目录 tiles/parallaxes/CloudySky1.png 已跳过
+[WARN] 未匹配的目录 tiles/parallaxes/Mountains2.png 已跳过
+[WARN] 未匹配的目录 tiles/parallaxes/Ocean2.png 已跳过
+[WARN] 未匹配的目录 tiles/parallaxes/Mountains5.png 已跳过
+[WARN] 未匹配的目录 tiles/parallaxes/BlueSky.png 已跳过
+[WARN] 未匹配的目录 tiles/parallaxes/Mountains3.png 已跳过
+[WARN] 未匹配的目录 tiles/parallaxes/DarkSpace2.png 已跳过
+[WARN] 未匹配的目录 tiles/parallaxes/CloudySky2.png 已跳过
+[WARN] 未匹配的目录 tiles/parallaxes/Mountains1.png 已跳过
+[WARN] 未匹配的目录 tiles/parallaxes/Ocean1.png 已跳过
+[WARN] 未匹配的目录 tiles/parallaxes/Sunset.png 已跳过
+[WARN] 未匹配的目录 tiles/parallaxes/SeaofClouds.png 已跳过
+[WARN] 未匹配的目录 tiles/parallaxes/DarkSpace1.png 已跳过
+[WARN] 未匹配的目录 tiles/parallaxes/StarlitSky.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Dungeon_A1.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Inside_A4.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Inside_C.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Outside_A3.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Dungeon_C.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Dungeon_B.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Outside_A2.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Outside_B.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Dungeon_B.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Outside_A2.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/World_A2.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Dungeon_A5.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Inside_A1.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Outside_A5.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Inside_A2.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Dungeon_A4.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/World_A2.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Dungeon_C.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Outside_A4.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/World_B.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Inside_A5.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Outside_A3.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Dungeon_A2.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Inside_A2.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Dungeon_A4.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Inside_B.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Dungeon_A1.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Inside_C.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/World_A1.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Outside_A1.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Outside_A1.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Dungeon_A2.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Outside_B.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Outside_C.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/World_B.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Inside_A1.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/World_A1.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Dungeon_A5.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Outside_A5.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Inside_A5.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Outside_C.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Inside_A4.png 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Inside_B.txt 已跳过
+[WARN] 未匹配的目录 tiles/tilesets/Outside_A4.txt 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Ruins1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/RockCave2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/DirtField.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Paved.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Road1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/PoisonSwamp.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/DemonicWorld1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/DemonicWorld2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Stone1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/RockCave1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Stone3.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Factory1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/DirtCave.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Lava2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Stone2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Clouds.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/DarkSpace.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Cobblestones4.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Castle.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Translucent.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Snowfield.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Ship.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Road2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Wasteland.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Factory2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Sky.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/DecorativeTile.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Dirt1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Crystal2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Meadow.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Cobblestones1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Dirt2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Road3.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Crystal1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/IceMaze.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/IceCave.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Ruins2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Fort.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/WireMesh.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Sand.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/DemonCastle.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Tent.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Cobblestones2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Grassland.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/LavaCave.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Ruins3.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Wood2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/GrassMaze.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Snow.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Lava1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/InBody.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Desert.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Cobblestones3.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks1/Wood1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/DemonCastle2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Castle1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Forest1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Crystal.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/RockCave.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Fort2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Fort1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Room2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/PoisonSwamp.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Stone1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Stone5.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Stone3.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Tower.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/DemonicWorld.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/DirtCave.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Port.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Stone2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Clouds.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/DarkSpace.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Castle2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Snowfield.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Ship.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Wasteland.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Town4.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Sky.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Sea.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Factory.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Brick.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Mine.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Town5.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Castle3.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Town2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Town3.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Forest2.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/IceMaze.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Ruins.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/IceCave.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Lava.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Town1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Temple.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Stone4.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Tent.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Room4.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Grassland.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/LavaCave.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Room1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/GrassMaze.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/DemonCastle3.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Room3.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/InBody.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Bridge.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Desert.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/DemonCastle1.png 已跳过
+[WARN] 未匹配的目录 tiles/battlebacks2/Cliff.png 已跳过
+[WARN] 未匹配的目录 ui/system/Shadow.png 已跳过
+[WARN] 未匹配的目录 ui/system/IconSet.png 已跳过
+[WARN] 未匹配的目录 ui/system/BattleStart.png 已跳过
+[WARN] 未匹配的目录 ui/system/Window.png 已跳过
+[WARN] 未匹配的目录 ui/system/Balloon.png 已跳过
+[WARN] 未匹配的目录 ui/system/GameOver.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Tower2.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Universe.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Dragon.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Crystal.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Island.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Devil.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Tower1.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/CrossedSwords.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Gates.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Castle.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Night.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Sword.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Hexagram.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Book.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Volcano.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Fountain.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/Plain.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/DemonCastle.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/World.png 已跳过
+[WARN] 未匹配的目录 ui/titles1/WorldMap.png 已跳过
+[WARN] 未匹配的目录 ui/titles2/Dragons.png 已跳过
+[WARN] 未匹配的目录 ui/titles2/Fire.png 已跳过
+[WARN] 未匹配的目录 ui/titles2/Heroes.png 已跳过
+[WARN] 未匹配的目录 ui/titles2/Mountains.png 已跳过
+[WARN] 未匹配的目录 ui/titles2/Gargoyles.png 已跳过
+[WARN] 未匹配的目录 ui/titles2/Forest.png 已跳过
+[WARN] 未匹配的目录 ui/titles2/Mist.png 已跳过
+[WARN] 未匹配的目录 ui/titles2/Metal.png 已跳过
+[WARN] 未匹配的目录 ui/titles2/Leaves.png 已跳过
+[WARN] 未匹配的目录 audio/bgm/Battle9.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm11戦闘プレジデント・宝条.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/Field4.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm15Hお使い.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/Scene4.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Town1.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm13H客.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/Theme2.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm09戦闘雑魚.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm17Hクラウド.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/Battle2.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Battle3.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Battle7.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Battle6.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Town3.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Scene2.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm02ステージ七番街スラム.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/Battle5.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Dungeon1.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Dungeon8.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Dungeon3.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm05ステージ神羅飛空艇.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/Field1.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm07ステージ神羅ビル.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/Scene6.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Dungeon7.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm12戦闘セフィロス.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/Dungeon4.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Dungeon6.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Battle1.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Theme4.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm03ステージウォールマーケット.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm06ステージコレルプリズン.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm08ステージ神羅屋敷.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/Theme1.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Town2.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Ship.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm16H敗北.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/Battle8.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm04ステージ弐番魔晄炉.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/Dungeon5.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Field3.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Town5.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Town4.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Field2.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Scene1.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Town6.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm14H仲間.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm10戦闘中ボス.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/Dungeon2.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Town7.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Battle4.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Theme5.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/bgm01ステージセブンスヘブン.mp3 已跳过
+[WARN] 未匹配的目录 audio/bgm/Airship.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Theme3.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Scene3.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Dungeon9.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgm/Scene5.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgs/Quake.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgs/Sea.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgs/Rain.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgs/Darkness.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgs/Drips.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgs/Storm.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgs/Fire.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgs/Wind.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgs/River.ogg 已跳过
+[WARN] 未匹配的目录 audio/bgs/Clock.ogg 已跳过
+[WARN] 未匹配的目录 audio/me/Gameover1.ogg 已跳过
+[WARN] 未匹配的目录 audio/me/Item.ogg 已跳过
+[WARN] 未匹配的目录 audio/me/Organ.ogg 已跳过
+[WARN] 未匹配的目录 audio/me/Gameover2.ogg 已跳过
+[WARN] 未匹配的目录 audio/me/Fanfare3.ogg 已跳过
+[WARN] 未匹配的目录 audio/me/Mystery.ogg 已跳过
+[WARN] 未匹配的目录 audio/me/Victory2.ogg 已跳过
+[WARN] 未匹配的目录 audio/me/Inn.ogg 已跳过
+[WARN] 未匹配的目录 audio/me/Fanfare1.ogg 已跳过
+[WARN] 未匹配的目录 audio/me/Shock.ogg 已跳过
+[WARN] 未匹配的目录 audio/me/Fanfare2.ogg 已跳过
+[WARN] 未匹配的目录 audio/me/Victory1.ogg 已跳过
+[WARN] 未匹配的目录 audio/me/Gag.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv31.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Dog.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Earth3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv58.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv19.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Sword5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Barrier.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Explosion5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Blow8.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Shot2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Thunder7.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Skill3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Thunder5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv57.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Cow.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Water1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Raise3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Scream.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Saint7.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Raise1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv47.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Switch3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Blow6.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Chest.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Crow.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Ice4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv35.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Explosion2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Ice6.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/ミッションクリア.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv59.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Absorb1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv03.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Blow2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv05.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Buzzer1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Powerup.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Bow3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Save.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Decision1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Attack3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Applause2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Monster6.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv21.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv07.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Buzzer2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Explosion4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Battle2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Ice9.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Damage1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Sound1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv13.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Battle3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Heal6.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Close1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Item2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Sword1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv44.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Slash5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Fire1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Damage5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Paralyze3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Earth7.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Saint9.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Open2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Earth2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Explosion1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Collapse4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Darkness3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Water6.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Sleep.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Monster1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Saint4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Thunder8.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv01.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Collapse1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Wind11.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/宝箱.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Wind10.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Slash2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Decision3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv42.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Down1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv18.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Attack1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv38.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Saint1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv50.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Magic5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Thunder9.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv48.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Sound2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Fire5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Up2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Book2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Poison.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Earth8.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Open5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Shop.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Teleport.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv54.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Ice2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Darkness5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Fall.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Disappointment.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Dive.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Crash.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Heal1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv64.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv52.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Bell1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Slash10.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Phone.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Darkness4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Ice10.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv10.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Jump2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Chime1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Sheep.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Shot1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Noise.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv56.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Bell2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Attack2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Explosion6.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Thunder11.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Slash11.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv45.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Blow4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Paralyze2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Slash7.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Magic4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Close3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Book1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Switch1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Switch2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Close2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Earth9.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Saint6.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Ice8.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Slash3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Saint5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Break.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Thunder2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Down3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Up3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Water4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Machine.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Fire6.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Shot3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Flash3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Water3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Thunder3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Fire3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv60.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Jump1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv37.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Earth4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Fire7.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Saint8.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Starlight.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Fire8.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Thunder10.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Hammer.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Magic1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Sand.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv20.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Autodoor.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Stare.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Magic6.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Equip1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Knock.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Saint2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Explosion7.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Darkness1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Run.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv51.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Fire4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv24.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Up4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Blow5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Darkness8.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Wind4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv33.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Blow7.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Darkness6.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Water5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Darkness2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Chime2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Devil2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Gun2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Reflection.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Battle1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv30.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Confuse.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv29.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Slash1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Wind6.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Sound3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Thunder12.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Bell3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Damage4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv43.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv25.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Parry.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Monster7.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Ice5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Slash9.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Paralyze1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Sword2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Sword3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Chicken.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv34.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Slash12.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Devil1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Resonance.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Damage3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv40.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Decision2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Push.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv08.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Wind7.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Heal2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Equip2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Earth5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Cry1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Ice3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Item1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Bow1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Evasion2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Thunder1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Wind2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv32.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Gun1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Skill1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Open3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Down2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Fire9.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Breath.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv28.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Darkness7.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Heal7.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Wind3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Sword4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Up1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Bite.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Pollen.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Blind.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Cancel1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Earth1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv55.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv46.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Cry2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv09.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv16.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv41.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Thunder4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Wind8.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Devil3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv49.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv15.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Thunder6.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Skill2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv26.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv27.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv22.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Down4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Laser.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Evasion1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Saint3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Heal3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Fog1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Load.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Raise2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Ice7.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv36.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Bow2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Wind5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Magic2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Cancel2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Move.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Silence.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Key.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Coin.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Earth6.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Crossbow.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Fire2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Wind1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Collapse3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Ice11.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Blow3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Magic3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Wind9.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Cursor2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv04.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv23.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Cat.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Heal5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Slash4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Miss.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv11.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Horse.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Flash1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Open1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Explosion3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Magic7.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Blow1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Item3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Cursor1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv14.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Flash2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Monster5.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Collapse2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv39.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv17.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Absorb2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Slash6.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Monster2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Fog2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Applause1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv53.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Damage2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Ice1.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Open4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv12.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv06.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Equip3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Monster4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Recovery.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Bow4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Slash8.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Heal4.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Monster3.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Water2.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/cv02.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Twine.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Frog.ogg 已跳过
+[WARN] 未匹配的目录 audio/se/Wolf.ogg 已跳过
+[INFO] Found 0 audio files, 0 image files
+[INFO] Wrote index: /workspace/PixelWorld/assets/build/index.json
+[DONE] Import finished without binary generation.
+[INFO] Start import (copy mode). Rules = default
+[WARN] 未匹配的目录 README.md 已跳过
+[WARN] 未匹配的目录 user_manifest.json 已跳过
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!$Gate2.png → /workspace/PixelWorld/assets/build/characters/!$Gate2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Animal.png → /workspace/PixelWorld/assets/build/characters/Animal.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People1.png → /workspace/PixelWorld/assets/build/characters/People1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Switch1.png → /workspace/PixelWorld/assets/build/characters/!Switch1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Vehicle.png → /workspace/PixelWorld/assets/build/characters/Vehicle.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Monster1.png → /workspace/PixelWorld/assets/build/characters/Monster1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/$BigMonster2.png → /workspace/PixelWorld/assets/build/characters/$BigMonster2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People3.png → /workspace/PixelWorld/assets/build/characters/People3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/$BigMonster1.png → /workspace/PixelWorld/assets/build/characters/$BigMonster1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Actor3.png → /workspace/PixelWorld/assets/build/characters/Actor3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Actor4.png → /workspace/PixelWorld/assets/build/characters/Actor4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People4.png → /workspace/PixelWorld/assets/build/characters/People4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Other2.png → /workspace/PixelWorld/assets/build/characters/!Other2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Evil.png → /workspace/PixelWorld/assets/build/characters/Evil.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People5.png → /workspace/PixelWorld/assets/build/characters/People5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Monster2.png → /workspace/PixelWorld/assets/build/characters/Monster2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Actor5.png → /workspace/PixelWorld/assets/build/characters/Actor5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People8.png → /workspace/PixelWorld/assets/build/characters/People8.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Behavior3.png → /workspace/PixelWorld/assets/build/characters/Behavior3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Actor1.png → /workspace/PixelWorld/assets/build/characters/Actor1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Riding.png → /workspace/PixelWorld/assets/build/characters/Riding.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Damage3.png → /workspace/PixelWorld/assets/build/characters/Damage3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People2.png → /workspace/PixelWorld/assets/build/characters/People2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Door3.png → /workspace/PixelWorld/assets/build/characters/!Door3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Switch2.png → /workspace/PixelWorld/assets/build/characters/!Switch2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/$Coffin.png → /workspace/PixelWorld/assets/build/characters/$Coffin.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Spiritual.png → /workspace/PixelWorld/assets/build/characters/Spiritual.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Door2.png → /workspace/PixelWorld/assets/build/characters/!Door2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Damage1.png → /workspace/PixelWorld/assets/build/characters/Damage1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Door1.png → /workspace/PixelWorld/assets/build/characters/!Door1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Crystal.png → /workspace/PixelWorld/assets/build/characters/!Crystal.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Insane2.png → /workspace/PixelWorld/assets/build/characters/Insane2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Insane1.png → /workspace/PixelWorld/assets/build/characters/Insane1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Damage4.png → /workspace/PixelWorld/assets/build/characters/Damage4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Behavior1.png → /workspace/PixelWorld/assets/build/characters/Behavior1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People7.png → /workspace/PixelWorld/assets/build/characters/People7.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Monster3.png → /workspace/PixelWorld/assets/build/characters/Monster3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Behavior4.png → /workspace/PixelWorld/assets/build/characters/Behavior4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Actor2.png → /workspace/PixelWorld/assets/build/characters/Actor2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Flame.png → /workspace/PixelWorld/assets/build/characters/!Flame.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People6.png → /workspace/PixelWorld/assets/build/characters/People6.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Behavior2.png → /workspace/PixelWorld/assets/build/characters/Behavior2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Other3.png → /workspace/PixelWorld/assets/build/characters/!Other3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Hexagram.png → /workspace/PixelWorld/assets/build/characters/!Hexagram.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Chest.png → /workspace/PixelWorld/assets/build/characters/!Chest.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Other1.png → /workspace/PixelWorld/assets/build/characters/!Other1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!$Gate1.png → /workspace/PixelWorld/assets/build/characters/!$Gate1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Damage2.png → /workspace/PixelWorld/assets/build/characters/Damage2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/People1.png → /workspace/PixelWorld/assets/build/characters/People1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Monster1.png → /workspace/PixelWorld/assets/build/characters/Monster1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/People3.png → /workspace/PixelWorld/assets/build/characters/People3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Actor3.png → /workspace/PixelWorld/assets/build/characters/Actor3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Actor4.png → /workspace/PixelWorld/assets/build/characters/Actor4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/People4.png → /workspace/PixelWorld/assets/build/characters/People4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Evil.png → /workspace/PixelWorld/assets/build/characters/Evil.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Actor5.png → /workspace/PixelWorld/assets/build/characters/Actor5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Actor1.png → /workspace/PixelWorld/assets/build/characters/Actor1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/People2.png → /workspace/PixelWorld/assets/build/characters/People2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Spiritual.png → /workspace/PixelWorld/assets/build/characters/Spiritual.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Actor2.png → /workspace/PixelWorld/assets/build/characters/Actor2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Assassin.png → /workspace/PixelWorld/assets/build/characters/Assassin.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Evilgod.png → /workspace/PixelWorld/assets/build/characters/Evilgod.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Grappler_m.png → /workspace/PixelWorld/assets/build/characters/Grappler_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Spider.png → /workspace/PixelWorld/assets/build/characters/Spider.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Asura.png → /workspace/PixelWorld/assets/build/characters/Asura.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Warrior_f.png → /workspace/PixelWorld/assets/build/characters/Warrior_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Soldier.png → /workspace/PixelWorld/assets/build/characters/Soldier.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Dragon.png → /workspace/PixelWorld/assets/build/characters/Dragon.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Sahagin.png → /workspace/PixelWorld/assets/build/characters/Sahagin.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Wizard_m.png → /workspace/PixelWorld/assets/build/characters/Wizard_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Gargoyle.png → /workspace/PixelWorld/assets/build/characters/Gargoyle.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Snake.png → /workspace/PixelWorld/assets/build/characters/Snake.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Willowisp.png → /workspace/PixelWorld/assets/build/characters/Willowisp.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Angel.png → /workspace/PixelWorld/assets/build/characters/Angel.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Imp.png → /workspace/PixelWorld/assets/build/characters/Imp.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Mimic.png → /workspace/PixelWorld/assets/build/characters/Mimic.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Plant.png → /workspace/PixelWorld/assets/build/characters/Plant.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Chimera.png → /workspace/PixelWorld/assets/build/characters/Chimera.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Windspirit.png → /workspace/PixelWorld/assets/build/characters/Windspirit.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Swordman.png → /workspace/PixelWorld/assets/build/characters/Swordman.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Thief_f.png → /workspace/PixelWorld/assets/build/characters/Thief_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Thief_m.png → /workspace/PixelWorld/assets/build/characters/Thief_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Kerberos.png → /workspace/PixelWorld/assets/build/characters/Kerberos.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Mage.png → /workspace/PixelWorld/assets/build/characters/Mage.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Garuda.png → /workspace/PixelWorld/assets/build/characters/Garuda.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Bandit.png → /workspace/PixelWorld/assets/build/characters/Bandit.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Behemoth.png → /workspace/PixelWorld/assets/build/characters/Behemoth.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Gayzer.png → /workspace/PixelWorld/assets/build/characters/Gayzer.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Werewolf.png → /workspace/PixelWorld/assets/build/characters/Werewolf.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Evilking.png → /workspace/PixelWorld/assets/build/characters/Evilking.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Wizard_f.png → /workspace/PixelWorld/assets/build/characters/Wizard_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Death.png → /workspace/PixelWorld/assets/build/characters/Death.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Ogre.png → /workspace/PixelWorld/assets/build/characters/Ogre.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Vampire.png → /workspace/PixelWorld/assets/build/characters/Vampire.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Hornet.png → /workspace/PixelWorld/assets/build/characters/Hornet.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Grappler_f.png → /workspace/PixelWorld/assets/build/characters/Grappler_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Ifrit.png → /workspace/PixelWorld/assets/build/characters/Ifrit.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Lamia.png → /workspace/PixelWorld/assets/build/characters/Lamia.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Ghost.png → /workspace/PixelWorld/assets/build/characters/Ghost.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Rat.png → /workspace/PixelWorld/assets/build/characters/Rat.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Fanatic.png → /workspace/PixelWorld/assets/build/characters/Fanatic.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Cleric_f.png → /workspace/PixelWorld/assets/build/characters/Cleric_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Firespirit.png → /workspace/PixelWorld/assets/build/characters/Firespirit.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Puppet.png → /workspace/PixelWorld/assets/build/characters/Puppet.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Slime.png → /workspace/PixelWorld/assets/build/characters/Slime.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Fairy.png → /workspace/PixelWorld/assets/build/characters/Fairy.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Zombie.png → /workspace/PixelWorld/assets/build/characters/Zombie.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Hero_m.png → /workspace/PixelWorld/assets/build/characters/Hero_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/General.png → /workspace/PixelWorld/assets/build/characters/General.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Captain.png → /workspace/PixelWorld/assets/build/characters/Captain.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Goddess.png → /workspace/PixelWorld/assets/build/characters/Goddess.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Earthspirit.png → /workspace/PixelWorld/assets/build/characters/Earthspirit.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Icelady.png → /workspace/PixelWorld/assets/build/characters/Icelady.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/God.png → /workspace/PixelWorld/assets/build/characters/God.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Paladin_f.png → /workspace/PixelWorld/assets/build/characters/Paladin_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Warrior_m.png → /workspace/PixelWorld/assets/build/characters/Warrior_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Hero_f.png → /workspace/PixelWorld/assets/build/characters/Hero_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Succubus.png → /workspace/PixelWorld/assets/build/characters/Succubus.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Delf_f.png → /workspace/PixelWorld/assets/build/characters/Delf_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Delf_m.png → /workspace/PixelWorld/assets/build/characters/Delf_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Orc.png → /workspace/PixelWorld/assets/build/characters/Orc.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Darklord.png → /workspace/PixelWorld/assets/build/characters/Darklord.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Cockatrice.png → /workspace/PixelWorld/assets/build/characters/Cockatrice.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Minotaur.png → /workspace/PixelWorld/assets/build/characters/Minotaur.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Rogue.png → /workspace/PixelWorld/assets/build/characters/Rogue.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Cleric_m.png → /workspace/PixelWorld/assets/build/characters/Cleric_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Waterspirit.png → /workspace/PixelWorld/assets/build/characters/Waterspirit.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Bat.png → /workspace/PixelWorld/assets/build/characters/Bat.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Skeleton.png → /workspace/PixelWorld/assets/build/characters/Skeleton.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Priest.png → /workspace/PixelWorld/assets/build/characters/Priest.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Scorpion.png → /workspace/PixelWorld/assets/build/characters/Scorpion.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Jellyfish.png → /workspace/PixelWorld/assets/build/characters/Jellyfish.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Paladin_m.png → /workspace/PixelWorld/assets/build/characters/Paladin_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Demon.png → /workspace/PixelWorld/assets/build/characters/Demon.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Water1.png → /workspace/PixelWorld/assets/build/effects/Water1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Light3.png → /workspace/PixelWorld/assets/build/effects/Light3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Ice5.png → /workspace/PixelWorld/assets/build/effects/Ice5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special4.png → /workspace/PixelWorld/assets/build/effects/Special4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Death1.png → /workspace/PixelWorld/assets/build/effects/Death1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Gun2.png → /workspace/PixelWorld/assets/build/effects/Gun2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Light6.png → /workspace/PixelWorld/assets/build/effects/Light6.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Darkness2.png → /workspace/PixelWorld/assets/build/effects/Darkness2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special1.png → /workspace/PixelWorld/assets/build/effects/Special1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Wind1.png → /workspace/PixelWorld/assets/build/effects/Wind1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Fire3.png → /workspace/PixelWorld/assets/build/effects/Fire3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Blow1.png → /workspace/PixelWorld/assets/build/effects/Blow1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Heal3.png → /workspace/PixelWorld/assets/build/effects/Heal3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special15.png → /workspace/PixelWorld/assets/build/effects/Special15.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Water2.png → /workspace/PixelWorld/assets/build/effects/Water2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Heal1.png → /workspace/PixelWorld/assets/build/effects/Heal1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Thunder4.png → /workspace/PixelWorld/assets/build/effects/Thunder4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/State4.png → /workspace/PixelWorld/assets/build/effects/State4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword3.png → /workspace/PixelWorld/assets/build/effects/Sword3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack10.png → /workspace/PixelWorld/assets/build/effects/Attack10.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword5.png → /workspace/PixelWorld/assets/build/effects/Sword5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special6.png → /workspace/PixelWorld/assets/build/effects/Special6.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Light2.png → /workspace/PixelWorld/assets/build/effects/Light2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack7.png → /workspace/PixelWorld/assets/build/effects/Attack7.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Thunder2.png → /workspace/PixelWorld/assets/build/effects/Thunder2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Heal5.png → /workspace/PixelWorld/assets/build/effects/Heal5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword1.png → /workspace/PixelWorld/assets/build/effects/Sword1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Spear3.png → /workspace/PixelWorld/assets/build/effects/Spear3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack1.png → /workspace/PixelWorld/assets/build/effects/Attack1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Fire1.png → /workspace/PixelWorld/assets/build/effects/Fire1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/State5.png → /workspace/PixelWorld/assets/build/effects/State5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/State3.png → /workspace/PixelWorld/assets/build/effects/State3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack2.png → /workspace/PixelWorld/assets/build/effects/Attack2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Thunder3.png → /workspace/PixelWorld/assets/build/effects/Thunder3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special3.png → /workspace/PixelWorld/assets/build/effects/Special3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack4.png → /workspace/PixelWorld/assets/build/effects/Attack4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword2.png → /workspace/PixelWorld/assets/build/effects/Sword2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack8.png → /workspace/PixelWorld/assets/build/effects/Attack8.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Ice4.png → /workspace/PixelWorld/assets/build/effects/Ice4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/State6.png → /workspace/PixelWorld/assets/build/effects/State6.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special10.png → /workspace/PixelWorld/assets/build/effects/Special10.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Fire2.png → /workspace/PixelWorld/assets/build/effects/Fire2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack6.png → /workspace/PixelWorld/assets/build/effects/Attack6.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack11.png → /workspace/PixelWorld/assets/build/effects/Attack11.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special2.png → /workspace/PixelWorld/assets/build/effects/Special2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Spear2.png → /workspace/PixelWorld/assets/build/effects/Spear2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Gun1.png → /workspace/PixelWorld/assets/build/effects/Gun1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Fire4.png → /workspace/PixelWorld/assets/build/effects/Fire4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Earth1.png → /workspace/PixelWorld/assets/build/effects/Earth1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Blow2.png → /workspace/PixelWorld/assets/build/effects/Blow2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack5.png → /workspace/PixelWorld/assets/build/effects/Attack5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/State2.png → /workspace/PixelWorld/assets/build/effects/State2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack9.png → /workspace/PixelWorld/assets/build/effects/Attack9.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Heal6.png → /workspace/PixelWorld/assets/build/effects/Heal6.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Light4.png → /workspace/PixelWorld/assets/build/effects/Light4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Heal2.png → /workspace/PixelWorld/assets/build/effects/Heal2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/State1.png → /workspace/PixelWorld/assets/build/effects/State1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack12.png → /workspace/PixelWorld/assets/build/effects/Attack12.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Earth2.png → /workspace/PixelWorld/assets/build/effects/Earth2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Light1.png → /workspace/PixelWorld/assets/build/effects/Light1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special16.png → /workspace/PixelWorld/assets/build/effects/Special16.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special13.png → /workspace/PixelWorld/assets/build/effects/Special13.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword6.png → /workspace/PixelWorld/assets/build/effects/Sword6.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Heal4.png → /workspace/PixelWorld/assets/build/effects/Heal4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special14.png → /workspace/PixelWorld/assets/build/effects/Special14.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Spear1.png → /workspace/PixelWorld/assets/build/effects/Spear1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Ice3.png → /workspace/PixelWorld/assets/build/effects/Ice3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Wind3.png → /workspace/PixelWorld/assets/build/effects/Wind3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special8.png → /workspace/PixelWorld/assets/build/effects/Special8.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Water3.png → /workspace/PixelWorld/assets/build/effects/Water3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Meteor.png → /workspace/PixelWorld/assets/build/effects/Meteor.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack3.png → /workspace/PixelWorld/assets/build/effects/Attack3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special9.png → /workspace/PixelWorld/assets/build/effects/Special9.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special12.png → /workspace/PixelWorld/assets/build/effects/Special12.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Earth3.png → /workspace/PixelWorld/assets/build/effects/Earth3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword10.png → /workspace/PixelWorld/assets/build/effects/Sword10.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Light7.png → /workspace/PixelWorld/assets/build/effects/Light7.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Ice1.png → /workspace/PixelWorld/assets/build/effects/Ice1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special17.png → /workspace/PixelWorld/assets/build/effects/Special17.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Wind2.png → /workspace/PixelWorld/assets/build/effects/Wind2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special11.png → /workspace/PixelWorld/assets/build/effects/Special11.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Darkness1.png → /workspace/PixelWorld/assets/build/effects/Darkness1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword7.png → /workspace/PixelWorld/assets/build/effects/Sword7.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword8.png → /workspace/PixelWorld/assets/build/effects/Sword8.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special7.png → /workspace/PixelWorld/assets/build/effects/Special7.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Darkness3.png → /workspace/PixelWorld/assets/build/effects/Darkness3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Thunder1.png → /workspace/PixelWorld/assets/build/effects/Thunder1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword4.png → /workspace/PixelWorld/assets/build/effects/Sword4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Blow3.png → /workspace/PixelWorld/assets/build/effects/Blow3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Light5.png → /workspace/PixelWorld/assets/build/effects/Light5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword9.png → /workspace/PixelWorld/assets/build/effects/Sword9.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Ice2.png → /workspace/PixelWorld/assets/build/effects/Ice2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special5.png → /workspace/PixelWorld/assets/build/effects/Special5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Mountains4.png → /workspace/PixelWorld/assets/build/tiles/Mountains4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/CloudySky1.png → /workspace/PixelWorld/assets/build/tiles/CloudySky1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Mountains2.png → /workspace/PixelWorld/assets/build/tiles/Mountains2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Ocean2.png → /workspace/PixelWorld/assets/build/tiles/Ocean2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Mountains5.png → /workspace/PixelWorld/assets/build/tiles/Mountains5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/BlueSky.png → /workspace/PixelWorld/assets/build/tiles/BlueSky.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Mountains3.png → /workspace/PixelWorld/assets/build/tiles/Mountains3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/DarkSpace2.png → /workspace/PixelWorld/assets/build/tiles/DarkSpace2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/CloudySky2.png → /workspace/PixelWorld/assets/build/tiles/CloudySky2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Mountains1.png → /workspace/PixelWorld/assets/build/tiles/Mountains1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Ocean1.png → /workspace/PixelWorld/assets/build/tiles/Ocean1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Sunset.png → /workspace/PixelWorld/assets/build/tiles/Sunset.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/SeaofClouds.png → /workspace/PixelWorld/assets/build/tiles/SeaofClouds.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/DarkSpace1.png → /workspace/PixelWorld/assets/build/tiles/DarkSpace1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/StarlitSky.png → /workspace/PixelWorld/assets/build/tiles/StarlitSky.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A1.txt → /workspace/PixelWorld/assets/build/tiles/Dungeon_A1.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A4.txt → /workspace/PixelWorld/assets/build/tiles/Inside_A4.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_C.txt → /workspace/PixelWorld/assets/build/tiles/Inside_C.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A3.txt → /workspace/PixelWorld/assets/build/tiles/Outside_A3.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_C.txt → /workspace/PixelWorld/assets/build/tiles/Dungeon_C.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_B.png → /workspace/PixelWorld/assets/build/tiles/Dungeon_B.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A2.png → /workspace/PixelWorld/assets/build/tiles/Outside_A2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_B.png → /workspace/PixelWorld/assets/build/tiles/Outside_B.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_B.txt → /workspace/PixelWorld/assets/build/tiles/Dungeon_B.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A2.txt → /workspace/PixelWorld/assets/build/tiles/Outside_A2.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/World_A2.png → /workspace/PixelWorld/assets/build/tiles/World_A2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A5.png → /workspace/PixelWorld/assets/build/tiles/Dungeon_A5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A1.png → /workspace/PixelWorld/assets/build/tiles/Inside_A1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A5.png → /workspace/PixelWorld/assets/build/tiles/Outside_A5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A2.txt → /workspace/PixelWorld/assets/build/tiles/Inside_A2.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A4.txt → /workspace/PixelWorld/assets/build/tiles/Dungeon_A4.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/World_A2.txt → /workspace/PixelWorld/assets/build/tiles/World_A2.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_C.png → /workspace/PixelWorld/assets/build/tiles/Dungeon_C.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A4.png → /workspace/PixelWorld/assets/build/tiles/Outside_A4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/World_B.txt → /workspace/PixelWorld/assets/build/tiles/World_B.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A5.png → /workspace/PixelWorld/assets/build/tiles/Inside_A5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A3.png → /workspace/PixelWorld/assets/build/tiles/Outside_A3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A2.txt → /workspace/PixelWorld/assets/build/tiles/Dungeon_A2.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A2.png → /workspace/PixelWorld/assets/build/tiles/Inside_A2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A4.png → /workspace/PixelWorld/assets/build/tiles/Dungeon_A4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_B.png → /workspace/PixelWorld/assets/build/tiles/Inside_B.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A1.png → /workspace/PixelWorld/assets/build/tiles/Dungeon_A1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_C.png → /workspace/PixelWorld/assets/build/tiles/Inside_C.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/World_A1.png → /workspace/PixelWorld/assets/build/tiles/World_A1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A1.png → /workspace/PixelWorld/assets/build/tiles/Outside_A1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A1.txt → /workspace/PixelWorld/assets/build/tiles/Outside_A1.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A2.png → /workspace/PixelWorld/assets/build/tiles/Dungeon_A2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_B.txt → /workspace/PixelWorld/assets/build/tiles/Outside_B.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_C.png → /workspace/PixelWorld/assets/build/tiles/Outside_C.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/World_B.png → /workspace/PixelWorld/assets/build/tiles/World_B.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A1.txt → /workspace/PixelWorld/assets/build/tiles/Inside_A1.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/World_A1.txt → /workspace/PixelWorld/assets/build/tiles/World_A1.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A5.txt → /workspace/PixelWorld/assets/build/tiles/Dungeon_A5.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A5.txt → /workspace/PixelWorld/assets/build/tiles/Outside_A5.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A5.txt → /workspace/PixelWorld/assets/build/tiles/Inside_A5.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_C.txt → /workspace/PixelWorld/assets/build/tiles/Outside_C.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A4.png → /workspace/PixelWorld/assets/build/tiles/Inside_A4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_B.txt → /workspace/PixelWorld/assets/build/tiles/Inside_B.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A4.txt → /workspace/PixelWorld/assets/build/tiles/Outside_A4.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Ruins1.png → /workspace/PixelWorld/assets/build/tiles/Ruins1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/RockCave2.png → /workspace/PixelWorld/assets/build/tiles/RockCave2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/DirtField.png → /workspace/PixelWorld/assets/build/tiles/DirtField.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Paved.png → /workspace/PixelWorld/assets/build/tiles/Paved.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Road1.png → /workspace/PixelWorld/assets/build/tiles/Road1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/PoisonSwamp.png → /workspace/PixelWorld/assets/build/tiles/PoisonSwamp.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/DemonicWorld1.png → /workspace/PixelWorld/assets/build/tiles/DemonicWorld1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/DemonicWorld2.png → /workspace/PixelWorld/assets/build/tiles/DemonicWorld2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Stone1.png → /workspace/PixelWorld/assets/build/tiles/Stone1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/RockCave1.png → /workspace/PixelWorld/assets/build/tiles/RockCave1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Stone3.png → /workspace/PixelWorld/assets/build/tiles/Stone3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Factory1.png → /workspace/PixelWorld/assets/build/tiles/Factory1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/DirtCave.png → /workspace/PixelWorld/assets/build/tiles/DirtCave.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Lava2.png → /workspace/PixelWorld/assets/build/tiles/Lava2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Stone2.png → /workspace/PixelWorld/assets/build/tiles/Stone2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Clouds.png → /workspace/PixelWorld/assets/build/tiles/Clouds.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/DarkSpace.png → /workspace/PixelWorld/assets/build/tiles/DarkSpace.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Cobblestones4.png → /workspace/PixelWorld/assets/build/tiles/Cobblestones4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Castle.png → /workspace/PixelWorld/assets/build/tiles/Castle.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Translucent.png → /workspace/PixelWorld/assets/build/tiles/Translucent.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Snowfield.png → /workspace/PixelWorld/assets/build/tiles/Snowfield.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Ship.png → /workspace/PixelWorld/assets/build/tiles/Ship.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Road2.png → /workspace/PixelWorld/assets/build/tiles/Road2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Wasteland.png → /workspace/PixelWorld/assets/build/tiles/Wasteland.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Factory2.png → /workspace/PixelWorld/assets/build/tiles/Factory2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Sky.png → /workspace/PixelWorld/assets/build/tiles/Sky.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/DecorativeTile.png → /workspace/PixelWorld/assets/build/tiles/DecorativeTile.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Dirt1.png → /workspace/PixelWorld/assets/build/tiles/Dirt1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Crystal2.png → /workspace/PixelWorld/assets/build/tiles/Crystal2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Meadow.png → /workspace/PixelWorld/assets/build/tiles/Meadow.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Cobblestones1.png → /workspace/PixelWorld/assets/build/tiles/Cobblestones1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Dirt2.png → /workspace/PixelWorld/assets/build/tiles/Dirt2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Road3.png → /workspace/PixelWorld/assets/build/tiles/Road3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Crystal1.png → /workspace/PixelWorld/assets/build/tiles/Crystal1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/IceMaze.png → /workspace/PixelWorld/assets/build/tiles/IceMaze.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/IceCave.png → /workspace/PixelWorld/assets/build/tiles/IceCave.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Ruins2.png → /workspace/PixelWorld/assets/build/tiles/Ruins2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Fort.png → /workspace/PixelWorld/assets/build/tiles/Fort.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/WireMesh.png → /workspace/PixelWorld/assets/build/tiles/WireMesh.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Sand.png → /workspace/PixelWorld/assets/build/tiles/Sand.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/DemonCastle.png → /workspace/PixelWorld/assets/build/tiles/DemonCastle.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Tent.png → /workspace/PixelWorld/assets/build/tiles/Tent.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Cobblestones2.png → /workspace/PixelWorld/assets/build/tiles/Cobblestones2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Grassland.png → /workspace/PixelWorld/assets/build/tiles/Grassland.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/LavaCave.png → /workspace/PixelWorld/assets/build/tiles/LavaCave.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Ruins3.png → /workspace/PixelWorld/assets/build/tiles/Ruins3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Wood2.png → /workspace/PixelWorld/assets/build/tiles/Wood2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/GrassMaze.png → /workspace/PixelWorld/assets/build/tiles/GrassMaze.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Snow.png → /workspace/PixelWorld/assets/build/tiles/Snow.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Lava1.png → /workspace/PixelWorld/assets/build/tiles/Lava1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/InBody.png → /workspace/PixelWorld/assets/build/tiles/InBody.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Desert.png → /workspace/PixelWorld/assets/build/tiles/Desert.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Cobblestones3.png → /workspace/PixelWorld/assets/build/tiles/Cobblestones3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Wood1.png → /workspace/PixelWorld/assets/build/tiles/Wood1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/DemonCastle2.png → /workspace/PixelWorld/assets/build/tiles/DemonCastle2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Castle1.png → /workspace/PixelWorld/assets/build/tiles/Castle1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Forest1.png → /workspace/PixelWorld/assets/build/tiles/Forest1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Crystal.png → /workspace/PixelWorld/assets/build/tiles/Crystal.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/RockCave.png → /workspace/PixelWorld/assets/build/tiles/RockCave.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Fort2.png → /workspace/PixelWorld/assets/build/tiles/Fort2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Fort1.png → /workspace/PixelWorld/assets/build/tiles/Fort1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Room2.png → /workspace/PixelWorld/assets/build/tiles/Room2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/PoisonSwamp.png → /workspace/PixelWorld/assets/build/tiles/PoisonSwamp.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Stone1.png → /workspace/PixelWorld/assets/build/tiles/Stone1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Stone5.png → /workspace/PixelWorld/assets/build/tiles/Stone5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Stone3.png → /workspace/PixelWorld/assets/build/tiles/Stone3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Tower.png → /workspace/PixelWorld/assets/build/tiles/Tower.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/DemonicWorld.png → /workspace/PixelWorld/assets/build/tiles/DemonicWorld.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/DirtCave.png → /workspace/PixelWorld/assets/build/tiles/DirtCave.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Port.png → /workspace/PixelWorld/assets/build/tiles/Port.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Stone2.png → /workspace/PixelWorld/assets/build/tiles/Stone2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Clouds.png → /workspace/PixelWorld/assets/build/tiles/Clouds.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/DarkSpace.png → /workspace/PixelWorld/assets/build/tiles/DarkSpace.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Castle2.png → /workspace/PixelWorld/assets/build/tiles/Castle2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Snowfield.png → /workspace/PixelWorld/assets/build/tiles/Snowfield.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Ship.png → /workspace/PixelWorld/assets/build/tiles/Ship.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Wasteland.png → /workspace/PixelWorld/assets/build/tiles/Wasteland.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Town4.png → /workspace/PixelWorld/assets/build/tiles/Town4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Sky.png → /workspace/PixelWorld/assets/build/tiles/Sky.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Sea.png → /workspace/PixelWorld/assets/build/tiles/Sea.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Factory.png → /workspace/PixelWorld/assets/build/tiles/Factory.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Brick.png → /workspace/PixelWorld/assets/build/tiles/Brick.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Mine.png → /workspace/PixelWorld/assets/build/tiles/Mine.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Town5.png → /workspace/PixelWorld/assets/build/tiles/Town5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Castle3.png → /workspace/PixelWorld/assets/build/tiles/Castle3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Town2.png → /workspace/PixelWorld/assets/build/tiles/Town2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Town3.png → /workspace/PixelWorld/assets/build/tiles/Town3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Forest2.png → /workspace/PixelWorld/assets/build/tiles/Forest2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/IceMaze.png → /workspace/PixelWorld/assets/build/tiles/IceMaze.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Ruins.png → /workspace/PixelWorld/assets/build/tiles/Ruins.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/IceCave.png → /workspace/PixelWorld/assets/build/tiles/IceCave.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Lava.png → /workspace/PixelWorld/assets/build/tiles/Lava.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Town1.png → /workspace/PixelWorld/assets/build/tiles/Town1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Temple.png → /workspace/PixelWorld/assets/build/tiles/Temple.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Stone4.png → /workspace/PixelWorld/assets/build/tiles/Stone4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Tent.png → /workspace/PixelWorld/assets/build/tiles/Tent.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Room4.png → /workspace/PixelWorld/assets/build/tiles/Room4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Grassland.png → /workspace/PixelWorld/assets/build/tiles/Grassland.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/LavaCave.png → /workspace/PixelWorld/assets/build/tiles/LavaCave.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Room1.png → /workspace/PixelWorld/assets/build/tiles/Room1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/GrassMaze.png → /workspace/PixelWorld/assets/build/tiles/GrassMaze.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/DemonCastle3.png → /workspace/PixelWorld/assets/build/tiles/DemonCastle3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Room3.png → /workspace/PixelWorld/assets/build/tiles/Room3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/InBody.png → /workspace/PixelWorld/assets/build/tiles/InBody.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Bridge.png → /workspace/PixelWorld/assets/build/tiles/Bridge.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Desert.png → /workspace/PixelWorld/assets/build/tiles/Desert.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/DemonCastle1.png → /workspace/PixelWorld/assets/build/tiles/DemonCastle1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Cliff.png → /workspace/PixelWorld/assets/build/tiles/Cliff.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/system/Shadow.png → /workspace/PixelWorld/assets/build/ui/Shadow.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/system/IconSet.png → /workspace/PixelWorld/assets/build/ui/IconSet.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/system/BattleStart.png → /workspace/PixelWorld/assets/build/ui/BattleStart.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/system/Window.png → /workspace/PixelWorld/assets/build/ui/Window.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/system/Balloon.png → /workspace/PixelWorld/assets/build/ui/Balloon.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/system/GameOver.png → /workspace/PixelWorld/assets/build/ui/GameOver.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Tower2.png → /workspace/PixelWorld/assets/build/ui/Tower2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Universe.png → /workspace/PixelWorld/assets/build/ui/Universe.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Dragon.png → /workspace/PixelWorld/assets/build/ui/Dragon.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Crystal.png → /workspace/PixelWorld/assets/build/ui/Crystal.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Island.png → /workspace/PixelWorld/assets/build/ui/Island.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Devil.png → /workspace/PixelWorld/assets/build/ui/Devil.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Tower1.png → /workspace/PixelWorld/assets/build/ui/Tower1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/CrossedSwords.png → /workspace/PixelWorld/assets/build/ui/CrossedSwords.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Gates.png → /workspace/PixelWorld/assets/build/ui/Gates.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Castle.png → /workspace/PixelWorld/assets/build/ui/Castle.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Night.png → /workspace/PixelWorld/assets/build/ui/Night.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Sword.png → /workspace/PixelWorld/assets/build/ui/Sword.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Hexagram.png → /workspace/PixelWorld/assets/build/ui/Hexagram.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Book.png → /workspace/PixelWorld/assets/build/ui/Book.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Volcano.png → /workspace/PixelWorld/assets/build/ui/Volcano.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Fountain.png → /workspace/PixelWorld/assets/build/ui/Fountain.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Plain.png → /workspace/PixelWorld/assets/build/ui/Plain.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/DemonCastle.png → /workspace/PixelWorld/assets/build/ui/DemonCastle.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/World.png → /workspace/PixelWorld/assets/build/ui/World.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/WorldMap.png → /workspace/PixelWorld/assets/build/ui/WorldMap.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Dragons.png → /workspace/PixelWorld/assets/build/ui/Dragons.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Fire.png → /workspace/PixelWorld/assets/build/ui/Fire.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Heroes.png → /workspace/PixelWorld/assets/build/ui/Heroes.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Mountains.png → /workspace/PixelWorld/assets/build/ui/Mountains.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Gargoyles.png → /workspace/PixelWorld/assets/build/ui/Gargoyles.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Forest.png → /workspace/PixelWorld/assets/build/ui/Forest.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Mist.png → /workspace/PixelWorld/assets/build/ui/Mist.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Metal.png → /workspace/PixelWorld/assets/build/ui/Metal.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Leaves.png → /workspace/PixelWorld/assets/build/ui/Leaves.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle9.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm11戦闘プレジデント・宝条.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm11戦闘プレジデント・宝条.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Field4.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Field4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm15Hお使い.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm15Hお使い.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Scene4.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Scene4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Town1.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Town1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm13H客.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm13H客.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Theme2.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Theme2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm09戦闘雑魚.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm09戦闘雑魚.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm17Hクラウド.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm17Hクラウド.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle2.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle3.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle7.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle6.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Town3.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Town3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Scene2.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Scene2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm02ステージ七番街スラム.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm02ステージ七番街スラム.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle5.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon1.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon8.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon3.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm05ステージ神羅飛空艇.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm05ステージ神羅飛空艇.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Field1.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Field1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm07ステージ神羅ビル.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm07ステージ神羅ビル.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Scene6.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Scene6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon7.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm12戦闘セフィロス.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm12戦闘セフィロス.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon4.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon6.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle1.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Theme4.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Theme4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm03ステージウォールマーケット.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm03ステージウォールマーケット.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm06ステージコレルプリズン.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm06ステージコレルプリズン.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm08ステージ神羅屋敷.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm08ステージ神羅屋敷.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Theme1.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Theme1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Town2.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Town2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Ship.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Ship.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm16H敗北.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm16H敗北.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle8.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm04ステージ弐番魔晄炉.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm04ステージ弐番魔晄炉.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon5.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Field3.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Field3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Town5.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Town5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Town4.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Town4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Field2.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Field2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Scene1.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Scene1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Town6.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Town6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm14H仲間.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm14H仲間.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm10戦闘中ボス.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm10戦闘中ボス.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon2.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Town7.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Town7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle4.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Theme5.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Theme5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm01ステージセブンスヘブン.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm01ステージセブンスヘブン.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Airship.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Airship.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Theme3.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Theme3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Scene3.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Scene3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon9.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Scene5.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Scene5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Quake.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Quake.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Sea.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Sea.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Rain.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Rain.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Darkness.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Darkness.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Drips.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Drips.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Storm.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Storm.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Fire.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Fire.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Wind.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Wind.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/River.ogg → /workspace/PixelWorld/assets/build/audio/bgs/River.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Clock.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Clock.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Gameover1.ogg → /workspace/PixelWorld/assets/build/audio/me/Gameover1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Item.ogg → /workspace/PixelWorld/assets/build/audio/me/Item.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Organ.ogg → /workspace/PixelWorld/assets/build/audio/me/Organ.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Gameover2.ogg → /workspace/PixelWorld/assets/build/audio/me/Gameover2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Fanfare3.ogg → /workspace/PixelWorld/assets/build/audio/me/Fanfare3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Mystery.ogg → /workspace/PixelWorld/assets/build/audio/me/Mystery.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Victory2.ogg → /workspace/PixelWorld/assets/build/audio/me/Victory2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Inn.ogg → /workspace/PixelWorld/assets/build/audio/me/Inn.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Fanfare1.ogg → /workspace/PixelWorld/assets/build/audio/me/Fanfare1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Shock.ogg → /workspace/PixelWorld/assets/build/audio/me/Shock.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Fanfare2.ogg → /workspace/PixelWorld/assets/build/audio/me/Fanfare2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Victory1.ogg → /workspace/PixelWorld/assets/build/audio/me/Victory1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Gag.ogg → /workspace/PixelWorld/assets/build/audio/me/Gag.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv31.ogg → /workspace/PixelWorld/assets/build/audio/se/cv31.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Dog.ogg → /workspace/PixelWorld/assets/build/audio/se/Dog.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth3.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv58.ogg → /workspace/PixelWorld/assets/build/audio/se/cv58.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv19.ogg → /workspace/PixelWorld/assets/build/audio/se/cv19.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sword5.ogg → /workspace/PixelWorld/assets/build/audio/se/Sword5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Barrier.ogg → /workspace/PixelWorld/assets/build/audio/se/Barrier.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Explosion5.ogg → /workspace/PixelWorld/assets/build/audio/se/Explosion5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow8.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Shot2.ogg → /workspace/PixelWorld/assets/build/audio/se/Shot2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder7.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Skill3.ogg → /workspace/PixelWorld/assets/build/audio/se/Skill3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder5.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv57.ogg → /workspace/PixelWorld/assets/build/audio/se/cv57.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cow.ogg → /workspace/PixelWorld/assets/build/audio/se/Cow.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Water1.ogg → /workspace/PixelWorld/assets/build/audio/se/Water1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Raise3.ogg → /workspace/PixelWorld/assets/build/audio/se/Raise3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Scream.ogg → /workspace/PixelWorld/assets/build/audio/se/Scream.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint7.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Raise1.ogg → /workspace/PixelWorld/assets/build/audio/se/Raise1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv47.ogg → /workspace/PixelWorld/assets/build/audio/se/cv47.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Switch3.ogg → /workspace/PixelWorld/assets/build/audio/se/Switch3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow6.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Chest.ogg → /workspace/PixelWorld/assets/build/audio/se/Chest.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Crow.ogg → /workspace/PixelWorld/assets/build/audio/se/Crow.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice4.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv35.ogg → /workspace/PixelWorld/assets/build/audio/se/cv35.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Explosion2.ogg → /workspace/PixelWorld/assets/build/audio/se/Explosion2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice6.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/ミッションクリア.ogg → /workspace/PixelWorld/assets/build/audio/se/ミッションクリア.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv59.ogg → /workspace/PixelWorld/assets/build/audio/se/cv59.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Absorb1.ogg → /workspace/PixelWorld/assets/build/audio/se/Absorb1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv03.ogg → /workspace/PixelWorld/assets/build/audio/se/cv03.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow2.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv05.ogg → /workspace/PixelWorld/assets/build/audio/se/cv05.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Buzzer1.ogg → /workspace/PixelWorld/assets/build/audio/se/Buzzer1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Powerup.ogg → /workspace/PixelWorld/assets/build/audio/se/Powerup.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bow3.ogg → /workspace/PixelWorld/assets/build/audio/se/Bow3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Save.ogg → /workspace/PixelWorld/assets/build/audio/se/Save.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Decision1.ogg → /workspace/PixelWorld/assets/build/audio/se/Decision1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Attack3.ogg → /workspace/PixelWorld/assets/build/audio/se/Attack3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Applause2.ogg → /workspace/PixelWorld/assets/build/audio/se/Applause2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Monster6.ogg → /workspace/PixelWorld/assets/build/audio/se/Monster6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv21.ogg → /workspace/PixelWorld/assets/build/audio/se/cv21.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv07.ogg → /workspace/PixelWorld/assets/build/audio/se/cv07.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Buzzer2.ogg → /workspace/PixelWorld/assets/build/audio/se/Buzzer2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Explosion4.ogg → /workspace/PixelWorld/assets/build/audio/se/Explosion4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Battle2.ogg → /workspace/PixelWorld/assets/build/audio/se/Battle2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice9.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Damage1.ogg → /workspace/PixelWorld/assets/build/audio/se/Damage1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sound1.ogg → /workspace/PixelWorld/assets/build/audio/se/Sound1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv13.ogg → /workspace/PixelWorld/assets/build/audio/se/cv13.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Battle3.ogg → /workspace/PixelWorld/assets/build/audio/se/Battle3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Heal6.ogg → /workspace/PixelWorld/assets/build/audio/se/Heal6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Close1.ogg → /workspace/PixelWorld/assets/build/audio/se/Close1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Item2.ogg → /workspace/PixelWorld/assets/build/audio/se/Item2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sword1.ogg → /workspace/PixelWorld/assets/build/audio/se/Sword1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv44.ogg → /workspace/PixelWorld/assets/build/audio/se/cv44.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash5.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire1.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Damage5.ogg → /workspace/PixelWorld/assets/build/audio/se/Damage5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Paralyze3.ogg → /workspace/PixelWorld/assets/build/audio/se/Paralyze3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth7.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint9.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Open2.ogg → /workspace/PixelWorld/assets/build/audio/se/Open2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth2.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Explosion1.ogg → /workspace/PixelWorld/assets/build/audio/se/Explosion1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Collapse4.ogg → /workspace/PixelWorld/assets/build/audio/se/Collapse4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness3.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Water6.ogg → /workspace/PixelWorld/assets/build/audio/se/Water6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sleep.ogg → /workspace/PixelWorld/assets/build/audio/se/Sleep.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Monster1.ogg → /workspace/PixelWorld/assets/build/audio/se/Monster1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint4.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder8.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv01.ogg → /workspace/PixelWorld/assets/build/audio/se/cv01.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Collapse1.ogg → /workspace/PixelWorld/assets/build/audio/se/Collapse1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind11.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind11.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/宝箱.ogg → /workspace/PixelWorld/assets/build/audio/se/宝箱.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind10.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind10.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash2.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Decision3.ogg → /workspace/PixelWorld/assets/build/audio/se/Decision3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv42.ogg → /workspace/PixelWorld/assets/build/audio/se/cv42.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Down1.ogg → /workspace/PixelWorld/assets/build/audio/se/Down1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv18.ogg → /workspace/PixelWorld/assets/build/audio/se/cv18.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Attack1.ogg → /workspace/PixelWorld/assets/build/audio/se/Attack1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv38.ogg → /workspace/PixelWorld/assets/build/audio/se/cv38.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint1.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv50.ogg → /workspace/PixelWorld/assets/build/audio/se/cv50.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Magic5.ogg → /workspace/PixelWorld/assets/build/audio/se/Magic5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder9.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv48.ogg → /workspace/PixelWorld/assets/build/audio/se/cv48.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sound2.ogg → /workspace/PixelWorld/assets/build/audio/se/Sound2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire5.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Up2.ogg → /workspace/PixelWorld/assets/build/audio/se/Up2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Book2.ogg → /workspace/PixelWorld/assets/build/audio/se/Book2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Poison.ogg → /workspace/PixelWorld/assets/build/audio/se/Poison.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth8.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Open5.ogg → /workspace/PixelWorld/assets/build/audio/se/Open5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Shop.ogg → /workspace/PixelWorld/assets/build/audio/se/Shop.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Teleport.ogg → /workspace/PixelWorld/assets/build/audio/se/Teleport.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv54.ogg → /workspace/PixelWorld/assets/build/audio/se/cv54.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice2.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness5.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fall.ogg → /workspace/PixelWorld/assets/build/audio/se/Fall.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Disappointment.ogg → /workspace/PixelWorld/assets/build/audio/se/Disappointment.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Dive.ogg → /workspace/PixelWorld/assets/build/audio/se/Dive.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Crash.ogg → /workspace/PixelWorld/assets/build/audio/se/Crash.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Heal1.ogg → /workspace/PixelWorld/assets/build/audio/se/Heal1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv64.ogg → /workspace/PixelWorld/assets/build/audio/se/cv64.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv52.ogg → /workspace/PixelWorld/assets/build/audio/se/cv52.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bell1.ogg → /workspace/PixelWorld/assets/build/audio/se/Bell1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash10.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash10.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Phone.ogg → /workspace/PixelWorld/assets/build/audio/se/Phone.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness4.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice10.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice10.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv10.ogg → /workspace/PixelWorld/assets/build/audio/se/cv10.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Jump2.ogg → /workspace/PixelWorld/assets/build/audio/se/Jump2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Chime1.ogg → /workspace/PixelWorld/assets/build/audio/se/Chime1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sheep.ogg → /workspace/PixelWorld/assets/build/audio/se/Sheep.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Shot1.ogg → /workspace/PixelWorld/assets/build/audio/se/Shot1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Noise.ogg → /workspace/PixelWorld/assets/build/audio/se/Noise.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv56.ogg → /workspace/PixelWorld/assets/build/audio/se/cv56.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bell2.ogg → /workspace/PixelWorld/assets/build/audio/se/Bell2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Attack2.ogg → /workspace/PixelWorld/assets/build/audio/se/Attack2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Explosion6.ogg → /workspace/PixelWorld/assets/build/audio/se/Explosion6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder11.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder11.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash11.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash11.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv45.ogg → /workspace/PixelWorld/assets/build/audio/se/cv45.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow4.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Paralyze2.ogg → /workspace/PixelWorld/assets/build/audio/se/Paralyze2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash7.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Magic4.ogg → /workspace/PixelWorld/assets/build/audio/se/Magic4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Close3.ogg → /workspace/PixelWorld/assets/build/audio/se/Close3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Book1.ogg → /workspace/PixelWorld/assets/build/audio/se/Book1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Switch1.ogg → /workspace/PixelWorld/assets/build/audio/se/Switch1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Switch2.ogg → /workspace/PixelWorld/assets/build/audio/se/Switch2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Close2.ogg → /workspace/PixelWorld/assets/build/audio/se/Close2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth9.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint6.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice8.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash3.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint5.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Break.ogg → /workspace/PixelWorld/assets/build/audio/se/Break.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder2.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Down3.ogg → /workspace/PixelWorld/assets/build/audio/se/Down3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Up3.ogg → /workspace/PixelWorld/assets/build/audio/se/Up3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Water4.ogg → /workspace/PixelWorld/assets/build/audio/se/Water4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Machine.ogg → /workspace/PixelWorld/assets/build/audio/se/Machine.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire6.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Shot3.ogg → /workspace/PixelWorld/assets/build/audio/se/Shot3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Flash3.ogg → /workspace/PixelWorld/assets/build/audio/se/Flash3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Water3.ogg → /workspace/PixelWorld/assets/build/audio/se/Water3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder3.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire3.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv60.ogg → /workspace/PixelWorld/assets/build/audio/se/cv60.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Jump1.ogg → /workspace/PixelWorld/assets/build/audio/se/Jump1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv37.ogg → /workspace/PixelWorld/assets/build/audio/se/cv37.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth4.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire7.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint8.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Starlight.ogg → /workspace/PixelWorld/assets/build/audio/se/Starlight.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire8.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder10.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder10.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Hammer.ogg → /workspace/PixelWorld/assets/build/audio/se/Hammer.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Magic1.ogg → /workspace/PixelWorld/assets/build/audio/se/Magic1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sand.ogg → /workspace/PixelWorld/assets/build/audio/se/Sand.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv20.ogg → /workspace/PixelWorld/assets/build/audio/se/cv20.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Autodoor.ogg → /workspace/PixelWorld/assets/build/audio/se/Autodoor.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Stare.ogg → /workspace/PixelWorld/assets/build/audio/se/Stare.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Magic6.ogg → /workspace/PixelWorld/assets/build/audio/se/Magic6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Equip1.ogg → /workspace/PixelWorld/assets/build/audio/se/Equip1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Knock.ogg → /workspace/PixelWorld/assets/build/audio/se/Knock.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint2.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Explosion7.ogg → /workspace/PixelWorld/assets/build/audio/se/Explosion7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness1.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Run.ogg → /workspace/PixelWorld/assets/build/audio/se/Run.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv51.ogg → /workspace/PixelWorld/assets/build/audio/se/cv51.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire4.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv24.ogg → /workspace/PixelWorld/assets/build/audio/se/cv24.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Up4.ogg → /workspace/PixelWorld/assets/build/audio/se/Up4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow5.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness8.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind4.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv33.ogg → /workspace/PixelWorld/assets/build/audio/se/cv33.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow7.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness6.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Water5.ogg → /workspace/PixelWorld/assets/build/audio/se/Water5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness2.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Chime2.ogg → /workspace/PixelWorld/assets/build/audio/se/Chime2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Devil2.ogg → /workspace/PixelWorld/assets/build/audio/se/Devil2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Gun2.ogg → /workspace/PixelWorld/assets/build/audio/se/Gun2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Reflection.ogg → /workspace/PixelWorld/assets/build/audio/se/Reflection.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Battle1.ogg → /workspace/PixelWorld/assets/build/audio/se/Battle1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv30.ogg → /workspace/PixelWorld/assets/build/audio/se/cv30.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Confuse.ogg → /workspace/PixelWorld/assets/build/audio/se/Confuse.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv29.ogg → /workspace/PixelWorld/assets/build/audio/se/cv29.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash1.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind6.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sound3.ogg → /workspace/PixelWorld/assets/build/audio/se/Sound3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder12.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder12.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bell3.ogg → /workspace/PixelWorld/assets/build/audio/se/Bell3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Damage4.ogg → /workspace/PixelWorld/assets/build/audio/se/Damage4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv43.ogg → /workspace/PixelWorld/assets/build/audio/se/cv43.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv25.ogg → /workspace/PixelWorld/assets/build/audio/se/cv25.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Parry.ogg → /workspace/PixelWorld/assets/build/audio/se/Parry.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Monster7.ogg → /workspace/PixelWorld/assets/build/audio/se/Monster7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice5.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash9.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Paralyze1.ogg → /workspace/PixelWorld/assets/build/audio/se/Paralyze1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sword2.ogg → /workspace/PixelWorld/assets/build/audio/se/Sword2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sword3.ogg → /workspace/PixelWorld/assets/build/audio/se/Sword3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Chicken.ogg → /workspace/PixelWorld/assets/build/audio/se/Chicken.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv34.ogg → /workspace/PixelWorld/assets/build/audio/se/cv34.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash12.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash12.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Devil1.ogg → /workspace/PixelWorld/assets/build/audio/se/Devil1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Resonance.ogg → /workspace/PixelWorld/assets/build/audio/se/Resonance.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Damage3.ogg → /workspace/PixelWorld/assets/build/audio/se/Damage3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv40.ogg → /workspace/PixelWorld/assets/build/audio/se/cv40.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Decision2.ogg → /workspace/PixelWorld/assets/build/audio/se/Decision2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Push.ogg → /workspace/PixelWorld/assets/build/audio/se/Push.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv08.ogg → /workspace/PixelWorld/assets/build/audio/se/cv08.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind7.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Heal2.ogg → /workspace/PixelWorld/assets/build/audio/se/Heal2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Equip2.ogg → /workspace/PixelWorld/assets/build/audio/se/Equip2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth5.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cry1.ogg → /workspace/PixelWorld/assets/build/audio/se/Cry1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice3.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Item1.ogg → /workspace/PixelWorld/assets/build/audio/se/Item1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bow1.ogg → /workspace/PixelWorld/assets/build/audio/se/Bow1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Evasion2.ogg → /workspace/PixelWorld/assets/build/audio/se/Evasion2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder1.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind2.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv32.ogg → /workspace/PixelWorld/assets/build/audio/se/cv32.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Gun1.ogg → /workspace/PixelWorld/assets/build/audio/se/Gun1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Skill1.ogg → /workspace/PixelWorld/assets/build/audio/se/Skill1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Open3.ogg → /workspace/PixelWorld/assets/build/audio/se/Open3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Down2.ogg → /workspace/PixelWorld/assets/build/audio/se/Down2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire9.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Breath.ogg → /workspace/PixelWorld/assets/build/audio/se/Breath.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv28.ogg → /workspace/PixelWorld/assets/build/audio/se/cv28.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness7.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Heal7.ogg → /workspace/PixelWorld/assets/build/audio/se/Heal7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind3.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sword4.ogg → /workspace/PixelWorld/assets/build/audio/se/Sword4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Up1.ogg → /workspace/PixelWorld/assets/build/audio/se/Up1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bite.ogg → /workspace/PixelWorld/assets/build/audio/se/Bite.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Pollen.ogg → /workspace/PixelWorld/assets/build/audio/se/Pollen.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blind.ogg → /workspace/PixelWorld/assets/build/audio/se/Blind.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cancel1.ogg → /workspace/PixelWorld/assets/build/audio/se/Cancel1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth1.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv55.ogg → /workspace/PixelWorld/assets/build/audio/se/cv55.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv46.ogg → /workspace/PixelWorld/assets/build/audio/se/cv46.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cry2.ogg → /workspace/PixelWorld/assets/build/audio/se/Cry2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv09.ogg → /workspace/PixelWorld/assets/build/audio/se/cv09.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv16.ogg → /workspace/PixelWorld/assets/build/audio/se/cv16.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv41.ogg → /workspace/PixelWorld/assets/build/audio/se/cv41.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder4.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind8.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Devil3.ogg → /workspace/PixelWorld/assets/build/audio/se/Devil3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv49.ogg → /workspace/PixelWorld/assets/build/audio/se/cv49.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv15.ogg → /workspace/PixelWorld/assets/build/audio/se/cv15.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder6.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Skill2.ogg → /workspace/PixelWorld/assets/build/audio/se/Skill2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv26.ogg → /workspace/PixelWorld/assets/build/audio/se/cv26.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv27.ogg → /workspace/PixelWorld/assets/build/audio/se/cv27.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv22.ogg → /workspace/PixelWorld/assets/build/audio/se/cv22.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Down4.ogg → /workspace/PixelWorld/assets/build/audio/se/Down4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Laser.ogg → /workspace/PixelWorld/assets/build/audio/se/Laser.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Evasion1.ogg → /workspace/PixelWorld/assets/build/audio/se/Evasion1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint3.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Heal3.ogg → /workspace/PixelWorld/assets/build/audio/se/Heal3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fog1.ogg → /workspace/PixelWorld/assets/build/audio/se/Fog1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Load.ogg → /workspace/PixelWorld/assets/build/audio/se/Load.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Raise2.ogg → /workspace/PixelWorld/assets/build/audio/se/Raise2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice7.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv36.ogg → /workspace/PixelWorld/assets/build/audio/se/cv36.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bow2.ogg → /workspace/PixelWorld/assets/build/audio/se/Bow2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind5.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Magic2.ogg → /workspace/PixelWorld/assets/build/audio/se/Magic2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cancel2.ogg → /workspace/PixelWorld/assets/build/audio/se/Cancel2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Move.ogg → /workspace/PixelWorld/assets/build/audio/se/Move.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Silence.ogg → /workspace/PixelWorld/assets/build/audio/se/Silence.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Key.ogg → /workspace/PixelWorld/assets/build/audio/se/Key.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Coin.ogg → /workspace/PixelWorld/assets/build/audio/se/Coin.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth6.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Crossbow.ogg → /workspace/PixelWorld/assets/build/audio/se/Crossbow.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire2.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind1.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Collapse3.ogg → /workspace/PixelWorld/assets/build/audio/se/Collapse3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice11.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice11.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow3.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Magic3.ogg → /workspace/PixelWorld/assets/build/audio/se/Magic3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind9.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cursor2.ogg → /workspace/PixelWorld/assets/build/audio/se/Cursor2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv04.ogg → /workspace/PixelWorld/assets/build/audio/se/cv04.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv23.ogg → /workspace/PixelWorld/assets/build/audio/se/cv23.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cat.ogg → /workspace/PixelWorld/assets/build/audio/se/Cat.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Heal5.ogg → /workspace/PixelWorld/assets/build/audio/se/Heal5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash4.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Miss.ogg → /workspace/PixelWorld/assets/build/audio/se/Miss.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv11.ogg → /workspace/PixelWorld/assets/build/audio/se/cv11.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Horse.ogg → /workspace/PixelWorld/assets/build/audio/se/Horse.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Flash1.ogg → /workspace/PixelWorld/assets/build/audio/se/Flash1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Open1.ogg → /workspace/PixelWorld/assets/build/audio/se/Open1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Explosion3.ogg → /workspace/PixelWorld/assets/build/audio/se/Explosion3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Magic7.ogg → /workspace/PixelWorld/assets/build/audio/se/Magic7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow1.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Item3.ogg → /workspace/PixelWorld/assets/build/audio/se/Item3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cursor1.ogg → /workspace/PixelWorld/assets/build/audio/se/Cursor1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv14.ogg → /workspace/PixelWorld/assets/build/audio/se/cv14.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Flash2.ogg → /workspace/PixelWorld/assets/build/audio/se/Flash2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Monster5.ogg → /workspace/PixelWorld/assets/build/audio/se/Monster5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Collapse2.ogg → /workspace/PixelWorld/assets/build/audio/se/Collapse2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv39.ogg → /workspace/PixelWorld/assets/build/audio/se/cv39.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv17.ogg → /workspace/PixelWorld/assets/build/audio/se/cv17.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Absorb2.ogg → /workspace/PixelWorld/assets/build/audio/se/Absorb2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash6.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Monster2.ogg → /workspace/PixelWorld/assets/build/audio/se/Monster2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fog2.ogg → /workspace/PixelWorld/assets/build/audio/se/Fog2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Applause1.ogg → /workspace/PixelWorld/assets/build/audio/se/Applause1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv53.ogg → /workspace/PixelWorld/assets/build/audio/se/cv53.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Damage2.ogg → /workspace/PixelWorld/assets/build/audio/se/Damage2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice1.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Open4.ogg → /workspace/PixelWorld/assets/build/audio/se/Open4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv12.ogg → /workspace/PixelWorld/assets/build/audio/se/cv12.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv06.ogg → /workspace/PixelWorld/assets/build/audio/se/cv06.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Equip3.ogg → /workspace/PixelWorld/assets/build/audio/se/Equip3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Monster4.ogg → /workspace/PixelWorld/assets/build/audio/se/Monster4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Recovery.ogg → /workspace/PixelWorld/assets/build/audio/se/Recovery.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bow4.ogg → /workspace/PixelWorld/assets/build/audio/se/Bow4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash8.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Heal4.ogg → /workspace/PixelWorld/assets/build/audio/se/Heal4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Monster3.ogg → /workspace/PixelWorld/assets/build/audio/se/Monster3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Water2.ogg → /workspace/PixelWorld/assets/build/audio/se/Water2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv02.ogg → /workspace/PixelWorld/assets/build/audio/se/cv02.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Twine.ogg → /workspace/PixelWorld/assets/build/audio/se/Twine.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Frog.ogg → /workspace/PixelWorld/assets/build/audio/se/Frog.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wolf.ogg → /workspace/PixelWorld/assets/build/audio/se/Wolf.ogg
+[INFO] Found 420 audio files, 429 image files
+[INFO] Wrote index: /workspace/PixelWorld/assets/build/index.json
+[DONE] Import finished without binary generation.
+[INFO] Start import (copy mode). Rules = default
+[WARN] 未匹配的目录 README.md 已跳过
+[WARN] 未匹配的目录 user_manifest.json 已跳过
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!$Gate2.png → /workspace/PixelWorld/assets/build/characters/!$Gate2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Animal.png → /workspace/PixelWorld/assets/build/characters/Animal.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People1.png → /workspace/PixelWorld/assets/build/characters/People1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Switch1.png → /workspace/PixelWorld/assets/build/characters/!Switch1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Vehicle.png → /workspace/PixelWorld/assets/build/characters/Vehicle.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Monster1.png → /workspace/PixelWorld/assets/build/characters/Monster1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/$BigMonster2.png → /workspace/PixelWorld/assets/build/characters/$BigMonster2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People3.png → /workspace/PixelWorld/assets/build/characters/People3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/$BigMonster1.png → /workspace/PixelWorld/assets/build/characters/$BigMonster1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Actor3.png → /workspace/PixelWorld/assets/build/characters/Actor3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Actor4.png → /workspace/PixelWorld/assets/build/characters/Actor4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People4.png → /workspace/PixelWorld/assets/build/characters/People4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Other2.png → /workspace/PixelWorld/assets/build/characters/!Other2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Evil.png → /workspace/PixelWorld/assets/build/characters/Evil.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People5.png → /workspace/PixelWorld/assets/build/characters/People5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Monster2.png → /workspace/PixelWorld/assets/build/characters/Monster2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Actor5.png → /workspace/PixelWorld/assets/build/characters/Actor5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People8.png → /workspace/PixelWorld/assets/build/characters/People8.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Behavior3.png → /workspace/PixelWorld/assets/build/characters/Behavior3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Actor1.png → /workspace/PixelWorld/assets/build/characters/Actor1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Riding.png → /workspace/PixelWorld/assets/build/characters/Riding.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Damage3.png → /workspace/PixelWorld/assets/build/characters/Damage3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People2.png → /workspace/PixelWorld/assets/build/characters/People2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Door3.png → /workspace/PixelWorld/assets/build/characters/!Door3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Switch2.png → /workspace/PixelWorld/assets/build/characters/!Switch2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/$Coffin.png → /workspace/PixelWorld/assets/build/characters/$Coffin.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Spiritual.png → /workspace/PixelWorld/assets/build/characters/Spiritual.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Door2.png → /workspace/PixelWorld/assets/build/characters/!Door2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Damage1.png → /workspace/PixelWorld/assets/build/characters/Damage1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Door1.png → /workspace/PixelWorld/assets/build/characters/!Door1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Crystal.png → /workspace/PixelWorld/assets/build/characters/!Crystal.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Insane2.png → /workspace/PixelWorld/assets/build/characters/Insane2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Insane1.png → /workspace/PixelWorld/assets/build/characters/Insane1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Damage4.png → /workspace/PixelWorld/assets/build/characters/Damage4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Behavior1.png → /workspace/PixelWorld/assets/build/characters/Behavior1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People7.png → /workspace/PixelWorld/assets/build/characters/People7.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Monster3.png → /workspace/PixelWorld/assets/build/characters/Monster3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Behavior4.png → /workspace/PixelWorld/assets/build/characters/Behavior4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Actor2.png → /workspace/PixelWorld/assets/build/characters/Actor2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Flame.png → /workspace/PixelWorld/assets/build/characters/!Flame.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/People6.png → /workspace/PixelWorld/assets/build/characters/People6.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Behavior2.png → /workspace/PixelWorld/assets/build/characters/Behavior2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Other3.png → /workspace/PixelWorld/assets/build/characters/!Other3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Hexagram.png → /workspace/PixelWorld/assets/build/characters/!Hexagram.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Chest.png → /workspace/PixelWorld/assets/build/characters/!Chest.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!Other1.png → /workspace/PixelWorld/assets/build/characters/!Other1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/!$Gate1.png → /workspace/PixelWorld/assets/build/characters/!$Gate1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/main/Damage2.png → /workspace/PixelWorld/assets/build/characters/Damage2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/People1.png → /workspace/PixelWorld/assets/build/characters/People1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Monster1.png → /workspace/PixelWorld/assets/build/characters/Monster1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/People3.png → /workspace/PixelWorld/assets/build/characters/People3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Actor3.png → /workspace/PixelWorld/assets/build/characters/Actor3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Actor4.png → /workspace/PixelWorld/assets/build/characters/Actor4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/People4.png → /workspace/PixelWorld/assets/build/characters/People4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Evil.png → /workspace/PixelWorld/assets/build/characters/Evil.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Actor5.png → /workspace/PixelWorld/assets/build/characters/Actor5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Actor1.png → /workspace/PixelWorld/assets/build/characters/Actor1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/People2.png → /workspace/PixelWorld/assets/build/characters/People2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Spiritual.png → /workspace/PixelWorld/assets/build/characters/Spiritual.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/faces/Actor2.png → /workspace/PixelWorld/assets/build/characters/Actor2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Assassin.png → /workspace/PixelWorld/assets/build/characters/Assassin.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Evilgod.png → /workspace/PixelWorld/assets/build/characters/Evilgod.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Grappler_m.png → /workspace/PixelWorld/assets/build/characters/Grappler_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Spider.png → /workspace/PixelWorld/assets/build/characters/Spider.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Asura.png → /workspace/PixelWorld/assets/build/characters/Asura.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Warrior_f.png → /workspace/PixelWorld/assets/build/characters/Warrior_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Soldier.png → /workspace/PixelWorld/assets/build/characters/Soldier.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Dragon.png → /workspace/PixelWorld/assets/build/characters/Dragon.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Sahagin.png → /workspace/PixelWorld/assets/build/characters/Sahagin.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Wizard_m.png → /workspace/PixelWorld/assets/build/characters/Wizard_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Gargoyle.png → /workspace/PixelWorld/assets/build/characters/Gargoyle.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Snake.png → /workspace/PixelWorld/assets/build/characters/Snake.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Willowisp.png → /workspace/PixelWorld/assets/build/characters/Willowisp.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Angel.png → /workspace/PixelWorld/assets/build/characters/Angel.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Imp.png → /workspace/PixelWorld/assets/build/characters/Imp.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Mimic.png → /workspace/PixelWorld/assets/build/characters/Mimic.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Plant.png → /workspace/PixelWorld/assets/build/characters/Plant.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Chimera.png → /workspace/PixelWorld/assets/build/characters/Chimera.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Windspirit.png → /workspace/PixelWorld/assets/build/characters/Windspirit.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Swordman.png → /workspace/PixelWorld/assets/build/characters/Swordman.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Thief_f.png → /workspace/PixelWorld/assets/build/characters/Thief_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Thief_m.png → /workspace/PixelWorld/assets/build/characters/Thief_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Kerberos.png → /workspace/PixelWorld/assets/build/characters/Kerberos.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Mage.png → /workspace/PixelWorld/assets/build/characters/Mage.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Garuda.png → /workspace/PixelWorld/assets/build/characters/Garuda.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Bandit.png → /workspace/PixelWorld/assets/build/characters/Bandit.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Behemoth.png → /workspace/PixelWorld/assets/build/characters/Behemoth.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Gayzer.png → /workspace/PixelWorld/assets/build/characters/Gayzer.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Werewolf.png → /workspace/PixelWorld/assets/build/characters/Werewolf.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Evilking.png → /workspace/PixelWorld/assets/build/characters/Evilking.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Wizard_f.png → /workspace/PixelWorld/assets/build/characters/Wizard_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Death.png → /workspace/PixelWorld/assets/build/characters/Death.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Ogre.png → /workspace/PixelWorld/assets/build/characters/Ogre.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Vampire.png → /workspace/PixelWorld/assets/build/characters/Vampire.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Hornet.png → /workspace/PixelWorld/assets/build/characters/Hornet.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Grappler_f.png → /workspace/PixelWorld/assets/build/characters/Grappler_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Ifrit.png → /workspace/PixelWorld/assets/build/characters/Ifrit.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Lamia.png → /workspace/PixelWorld/assets/build/characters/Lamia.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Ghost.png → /workspace/PixelWorld/assets/build/characters/Ghost.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Rat.png → /workspace/PixelWorld/assets/build/characters/Rat.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Fanatic.png → /workspace/PixelWorld/assets/build/characters/Fanatic.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Cleric_f.png → /workspace/PixelWorld/assets/build/characters/Cleric_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Firespirit.png → /workspace/PixelWorld/assets/build/characters/Firespirit.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Puppet.png → /workspace/PixelWorld/assets/build/characters/Puppet.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Slime.png → /workspace/PixelWorld/assets/build/characters/Slime.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Fairy.png → /workspace/PixelWorld/assets/build/characters/Fairy.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Zombie.png → /workspace/PixelWorld/assets/build/characters/Zombie.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Hero_m.png → /workspace/PixelWorld/assets/build/characters/Hero_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/General.png → /workspace/PixelWorld/assets/build/characters/General.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Captain.png → /workspace/PixelWorld/assets/build/characters/Captain.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Goddess.png → /workspace/PixelWorld/assets/build/characters/Goddess.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Earthspirit.png → /workspace/PixelWorld/assets/build/characters/Earthspirit.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Icelady.png → /workspace/PixelWorld/assets/build/characters/Icelady.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/God.png → /workspace/PixelWorld/assets/build/characters/God.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Paladin_f.png → /workspace/PixelWorld/assets/build/characters/Paladin_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Warrior_m.png → /workspace/PixelWorld/assets/build/characters/Warrior_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Hero_f.png → /workspace/PixelWorld/assets/build/characters/Hero_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Succubus.png → /workspace/PixelWorld/assets/build/characters/Succubus.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Delf_f.png → /workspace/PixelWorld/assets/build/characters/Delf_f.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Delf_m.png → /workspace/PixelWorld/assets/build/characters/Delf_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Orc.png → /workspace/PixelWorld/assets/build/characters/Orc.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Darklord.png → /workspace/PixelWorld/assets/build/characters/Darklord.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Cockatrice.png → /workspace/PixelWorld/assets/build/characters/Cockatrice.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Minotaur.png → /workspace/PixelWorld/assets/build/characters/Minotaur.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Rogue.png → /workspace/PixelWorld/assets/build/characters/Rogue.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Cleric_m.png → /workspace/PixelWorld/assets/build/characters/Cleric_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Waterspirit.png → /workspace/PixelWorld/assets/build/characters/Waterspirit.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Bat.png → /workspace/PixelWorld/assets/build/characters/Bat.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Skeleton.png → /workspace/PixelWorld/assets/build/characters/Skeleton.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Priest.png → /workspace/PixelWorld/assets/build/characters/Priest.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Scorpion.png → /workspace/PixelWorld/assets/build/characters/Scorpion.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Jellyfish.png → /workspace/PixelWorld/assets/build/characters/Jellyfish.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Paladin_m.png → /workspace/PixelWorld/assets/build/characters/Paladin_m.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/characters/battlers/Demon.png → /workspace/PixelWorld/assets/build/characters/Demon.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Water1.png → /workspace/PixelWorld/assets/build/effects/Water1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Light3.png → /workspace/PixelWorld/assets/build/effects/Light3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Ice5.png → /workspace/PixelWorld/assets/build/effects/Ice5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special4.png → /workspace/PixelWorld/assets/build/effects/Special4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Death1.png → /workspace/PixelWorld/assets/build/effects/Death1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Gun2.png → /workspace/PixelWorld/assets/build/effects/Gun2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Light6.png → /workspace/PixelWorld/assets/build/effects/Light6.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Darkness2.png → /workspace/PixelWorld/assets/build/effects/Darkness2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special1.png → /workspace/PixelWorld/assets/build/effects/Special1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Wind1.png → /workspace/PixelWorld/assets/build/effects/Wind1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Fire3.png → /workspace/PixelWorld/assets/build/effects/Fire3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Blow1.png → /workspace/PixelWorld/assets/build/effects/Blow1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Heal3.png → /workspace/PixelWorld/assets/build/effects/Heal3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special15.png → /workspace/PixelWorld/assets/build/effects/Special15.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Water2.png → /workspace/PixelWorld/assets/build/effects/Water2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Heal1.png → /workspace/PixelWorld/assets/build/effects/Heal1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Thunder4.png → /workspace/PixelWorld/assets/build/effects/Thunder4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/State4.png → /workspace/PixelWorld/assets/build/effects/State4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword3.png → /workspace/PixelWorld/assets/build/effects/Sword3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack10.png → /workspace/PixelWorld/assets/build/effects/Attack10.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword5.png → /workspace/PixelWorld/assets/build/effects/Sword5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special6.png → /workspace/PixelWorld/assets/build/effects/Special6.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Light2.png → /workspace/PixelWorld/assets/build/effects/Light2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack7.png → /workspace/PixelWorld/assets/build/effects/Attack7.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Thunder2.png → /workspace/PixelWorld/assets/build/effects/Thunder2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Heal5.png → /workspace/PixelWorld/assets/build/effects/Heal5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword1.png → /workspace/PixelWorld/assets/build/effects/Sword1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Spear3.png → /workspace/PixelWorld/assets/build/effects/Spear3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack1.png → /workspace/PixelWorld/assets/build/effects/Attack1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Fire1.png → /workspace/PixelWorld/assets/build/effects/Fire1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/State5.png → /workspace/PixelWorld/assets/build/effects/State5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/State3.png → /workspace/PixelWorld/assets/build/effects/State3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack2.png → /workspace/PixelWorld/assets/build/effects/Attack2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Thunder3.png → /workspace/PixelWorld/assets/build/effects/Thunder3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special3.png → /workspace/PixelWorld/assets/build/effects/Special3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack4.png → /workspace/PixelWorld/assets/build/effects/Attack4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword2.png → /workspace/PixelWorld/assets/build/effects/Sword2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack8.png → /workspace/PixelWorld/assets/build/effects/Attack8.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Ice4.png → /workspace/PixelWorld/assets/build/effects/Ice4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/State6.png → /workspace/PixelWorld/assets/build/effects/State6.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special10.png → /workspace/PixelWorld/assets/build/effects/Special10.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Fire2.png → /workspace/PixelWorld/assets/build/effects/Fire2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack6.png → /workspace/PixelWorld/assets/build/effects/Attack6.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack11.png → /workspace/PixelWorld/assets/build/effects/Attack11.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special2.png → /workspace/PixelWorld/assets/build/effects/Special2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Spear2.png → /workspace/PixelWorld/assets/build/effects/Spear2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Gun1.png → /workspace/PixelWorld/assets/build/effects/Gun1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Fire4.png → /workspace/PixelWorld/assets/build/effects/Fire4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Earth1.png → /workspace/PixelWorld/assets/build/effects/Earth1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Blow2.png → /workspace/PixelWorld/assets/build/effects/Blow2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack5.png → /workspace/PixelWorld/assets/build/effects/Attack5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/State2.png → /workspace/PixelWorld/assets/build/effects/State2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack9.png → /workspace/PixelWorld/assets/build/effects/Attack9.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Heal6.png → /workspace/PixelWorld/assets/build/effects/Heal6.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Light4.png → /workspace/PixelWorld/assets/build/effects/Light4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Heal2.png → /workspace/PixelWorld/assets/build/effects/Heal2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/State1.png → /workspace/PixelWorld/assets/build/effects/State1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack12.png → /workspace/PixelWorld/assets/build/effects/Attack12.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Earth2.png → /workspace/PixelWorld/assets/build/effects/Earth2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Light1.png → /workspace/PixelWorld/assets/build/effects/Light1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special16.png → /workspace/PixelWorld/assets/build/effects/Special16.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special13.png → /workspace/PixelWorld/assets/build/effects/Special13.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword6.png → /workspace/PixelWorld/assets/build/effects/Sword6.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Heal4.png → /workspace/PixelWorld/assets/build/effects/Heal4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special14.png → /workspace/PixelWorld/assets/build/effects/Special14.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Spear1.png → /workspace/PixelWorld/assets/build/effects/Spear1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Ice3.png → /workspace/PixelWorld/assets/build/effects/Ice3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Wind3.png → /workspace/PixelWorld/assets/build/effects/Wind3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special8.png → /workspace/PixelWorld/assets/build/effects/Special8.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Water3.png → /workspace/PixelWorld/assets/build/effects/Water3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Meteor.png → /workspace/PixelWorld/assets/build/effects/Meteor.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Attack3.png → /workspace/PixelWorld/assets/build/effects/Attack3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special9.png → /workspace/PixelWorld/assets/build/effects/Special9.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special12.png → /workspace/PixelWorld/assets/build/effects/Special12.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Earth3.png → /workspace/PixelWorld/assets/build/effects/Earth3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword10.png → /workspace/PixelWorld/assets/build/effects/Sword10.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Light7.png → /workspace/PixelWorld/assets/build/effects/Light7.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Ice1.png → /workspace/PixelWorld/assets/build/effects/Ice1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special17.png → /workspace/PixelWorld/assets/build/effects/Special17.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Wind2.png → /workspace/PixelWorld/assets/build/effects/Wind2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special11.png → /workspace/PixelWorld/assets/build/effects/Special11.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Darkness1.png → /workspace/PixelWorld/assets/build/effects/Darkness1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword7.png → /workspace/PixelWorld/assets/build/effects/Sword7.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword8.png → /workspace/PixelWorld/assets/build/effects/Sword8.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special7.png → /workspace/PixelWorld/assets/build/effects/Special7.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Darkness3.png → /workspace/PixelWorld/assets/build/effects/Darkness3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Thunder1.png → /workspace/PixelWorld/assets/build/effects/Thunder1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword4.png → /workspace/PixelWorld/assets/build/effects/Sword4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Blow3.png → /workspace/PixelWorld/assets/build/effects/Blow3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Light5.png → /workspace/PixelWorld/assets/build/effects/Light5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Sword9.png → /workspace/PixelWorld/assets/build/effects/Sword9.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Ice2.png → /workspace/PixelWorld/assets/build/effects/Ice2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/effects/animations/Special5.png → /workspace/PixelWorld/assets/build/effects/Special5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Mountains4.png → /workspace/PixelWorld/assets/build/tiles/Mountains4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/CloudySky1.png → /workspace/PixelWorld/assets/build/tiles/CloudySky1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Mountains2.png → /workspace/PixelWorld/assets/build/tiles/Mountains2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Ocean2.png → /workspace/PixelWorld/assets/build/tiles/Ocean2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Mountains5.png → /workspace/PixelWorld/assets/build/tiles/Mountains5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/BlueSky.png → /workspace/PixelWorld/assets/build/tiles/BlueSky.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Mountains3.png → /workspace/PixelWorld/assets/build/tiles/Mountains3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/DarkSpace2.png → /workspace/PixelWorld/assets/build/tiles/DarkSpace2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/CloudySky2.png → /workspace/PixelWorld/assets/build/tiles/CloudySky2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Mountains1.png → /workspace/PixelWorld/assets/build/tiles/Mountains1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Ocean1.png → /workspace/PixelWorld/assets/build/tiles/Ocean1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/Sunset.png → /workspace/PixelWorld/assets/build/tiles/Sunset.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/SeaofClouds.png → /workspace/PixelWorld/assets/build/tiles/SeaofClouds.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/DarkSpace1.png → /workspace/PixelWorld/assets/build/tiles/DarkSpace1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/parallaxes/StarlitSky.png → /workspace/PixelWorld/assets/build/tiles/StarlitSky.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A1.txt → /workspace/PixelWorld/assets/build/tiles/Dungeon_A1.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A4.txt → /workspace/PixelWorld/assets/build/tiles/Inside_A4.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_C.txt → /workspace/PixelWorld/assets/build/tiles/Inside_C.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A3.txt → /workspace/PixelWorld/assets/build/tiles/Outside_A3.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_C.txt → /workspace/PixelWorld/assets/build/tiles/Dungeon_C.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_B.png → /workspace/PixelWorld/assets/build/tiles/Dungeon_B.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A2.png → /workspace/PixelWorld/assets/build/tiles/Outside_A2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_B.png → /workspace/PixelWorld/assets/build/tiles/Outside_B.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_B.txt → /workspace/PixelWorld/assets/build/tiles/Dungeon_B.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A2.txt → /workspace/PixelWorld/assets/build/tiles/Outside_A2.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/World_A2.png → /workspace/PixelWorld/assets/build/tiles/World_A2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A5.png → /workspace/PixelWorld/assets/build/tiles/Dungeon_A5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A1.png → /workspace/PixelWorld/assets/build/tiles/Inside_A1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A5.png → /workspace/PixelWorld/assets/build/tiles/Outside_A5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A2.txt → /workspace/PixelWorld/assets/build/tiles/Inside_A2.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A4.txt → /workspace/PixelWorld/assets/build/tiles/Dungeon_A4.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/World_A2.txt → /workspace/PixelWorld/assets/build/tiles/World_A2.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_C.png → /workspace/PixelWorld/assets/build/tiles/Dungeon_C.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A4.png → /workspace/PixelWorld/assets/build/tiles/Outside_A4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/World_B.txt → /workspace/PixelWorld/assets/build/tiles/World_B.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A5.png → /workspace/PixelWorld/assets/build/tiles/Inside_A5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A3.png → /workspace/PixelWorld/assets/build/tiles/Outside_A3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A2.txt → /workspace/PixelWorld/assets/build/tiles/Dungeon_A2.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A2.png → /workspace/PixelWorld/assets/build/tiles/Inside_A2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A4.png → /workspace/PixelWorld/assets/build/tiles/Dungeon_A4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_B.png → /workspace/PixelWorld/assets/build/tiles/Inside_B.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A1.png → /workspace/PixelWorld/assets/build/tiles/Dungeon_A1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_C.png → /workspace/PixelWorld/assets/build/tiles/Inside_C.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/World_A1.png → /workspace/PixelWorld/assets/build/tiles/World_A1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A1.png → /workspace/PixelWorld/assets/build/tiles/Outside_A1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A1.txt → /workspace/PixelWorld/assets/build/tiles/Outside_A1.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A2.png → /workspace/PixelWorld/assets/build/tiles/Dungeon_A2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_B.txt → /workspace/PixelWorld/assets/build/tiles/Outside_B.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_C.png → /workspace/PixelWorld/assets/build/tiles/Outside_C.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/World_B.png → /workspace/PixelWorld/assets/build/tiles/World_B.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A1.txt → /workspace/PixelWorld/assets/build/tiles/Inside_A1.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/World_A1.txt → /workspace/PixelWorld/assets/build/tiles/World_A1.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Dungeon_A5.txt → /workspace/PixelWorld/assets/build/tiles/Dungeon_A5.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A5.txt → /workspace/PixelWorld/assets/build/tiles/Outside_A5.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A5.txt → /workspace/PixelWorld/assets/build/tiles/Inside_A5.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_C.txt → /workspace/PixelWorld/assets/build/tiles/Outside_C.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_A4.png → /workspace/PixelWorld/assets/build/tiles/Inside_A4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Inside_B.txt → /workspace/PixelWorld/assets/build/tiles/Inside_B.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/tilesets/Outside_A4.txt → /workspace/PixelWorld/assets/build/tiles/Outside_A4.txt
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Ruins1.png → /workspace/PixelWorld/assets/build/tiles/Ruins1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/RockCave2.png → /workspace/PixelWorld/assets/build/tiles/RockCave2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/DirtField.png → /workspace/PixelWorld/assets/build/tiles/DirtField.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Paved.png → /workspace/PixelWorld/assets/build/tiles/Paved.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Road1.png → /workspace/PixelWorld/assets/build/tiles/Road1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/PoisonSwamp.png → /workspace/PixelWorld/assets/build/tiles/PoisonSwamp.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/DemonicWorld1.png → /workspace/PixelWorld/assets/build/tiles/DemonicWorld1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/DemonicWorld2.png → /workspace/PixelWorld/assets/build/tiles/DemonicWorld2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Stone1.png → /workspace/PixelWorld/assets/build/tiles/Stone1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/RockCave1.png → /workspace/PixelWorld/assets/build/tiles/RockCave1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Stone3.png → /workspace/PixelWorld/assets/build/tiles/Stone3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Factory1.png → /workspace/PixelWorld/assets/build/tiles/Factory1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/DirtCave.png → /workspace/PixelWorld/assets/build/tiles/DirtCave.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Lava2.png → /workspace/PixelWorld/assets/build/tiles/Lava2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Stone2.png → /workspace/PixelWorld/assets/build/tiles/Stone2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Clouds.png → /workspace/PixelWorld/assets/build/tiles/Clouds.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/DarkSpace.png → /workspace/PixelWorld/assets/build/tiles/DarkSpace.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Cobblestones4.png → /workspace/PixelWorld/assets/build/tiles/Cobblestones4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Castle.png → /workspace/PixelWorld/assets/build/tiles/Castle.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Translucent.png → /workspace/PixelWorld/assets/build/tiles/Translucent.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Snowfield.png → /workspace/PixelWorld/assets/build/tiles/Snowfield.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Ship.png → /workspace/PixelWorld/assets/build/tiles/Ship.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Road2.png → /workspace/PixelWorld/assets/build/tiles/Road2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Wasteland.png → /workspace/PixelWorld/assets/build/tiles/Wasteland.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Factory2.png → /workspace/PixelWorld/assets/build/tiles/Factory2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Sky.png → /workspace/PixelWorld/assets/build/tiles/Sky.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/DecorativeTile.png → /workspace/PixelWorld/assets/build/tiles/DecorativeTile.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Dirt1.png → /workspace/PixelWorld/assets/build/tiles/Dirt1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Crystal2.png → /workspace/PixelWorld/assets/build/tiles/Crystal2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Meadow.png → /workspace/PixelWorld/assets/build/tiles/Meadow.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Cobblestones1.png → /workspace/PixelWorld/assets/build/tiles/Cobblestones1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Dirt2.png → /workspace/PixelWorld/assets/build/tiles/Dirt2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Road3.png → /workspace/PixelWorld/assets/build/tiles/Road3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Crystal1.png → /workspace/PixelWorld/assets/build/tiles/Crystal1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/IceMaze.png → /workspace/PixelWorld/assets/build/tiles/IceMaze.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/IceCave.png → /workspace/PixelWorld/assets/build/tiles/IceCave.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Ruins2.png → /workspace/PixelWorld/assets/build/tiles/Ruins2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Fort.png → /workspace/PixelWorld/assets/build/tiles/Fort.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/WireMesh.png → /workspace/PixelWorld/assets/build/tiles/WireMesh.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Sand.png → /workspace/PixelWorld/assets/build/tiles/Sand.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/DemonCastle.png → /workspace/PixelWorld/assets/build/tiles/DemonCastle.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Tent.png → /workspace/PixelWorld/assets/build/tiles/Tent.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Cobblestones2.png → /workspace/PixelWorld/assets/build/tiles/Cobblestones2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Grassland.png → /workspace/PixelWorld/assets/build/tiles/Grassland.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/LavaCave.png → /workspace/PixelWorld/assets/build/tiles/LavaCave.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Ruins3.png → /workspace/PixelWorld/assets/build/tiles/Ruins3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Wood2.png → /workspace/PixelWorld/assets/build/tiles/Wood2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/GrassMaze.png → /workspace/PixelWorld/assets/build/tiles/GrassMaze.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Snow.png → /workspace/PixelWorld/assets/build/tiles/Snow.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Lava1.png → /workspace/PixelWorld/assets/build/tiles/Lava1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/InBody.png → /workspace/PixelWorld/assets/build/tiles/InBody.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Desert.png → /workspace/PixelWorld/assets/build/tiles/Desert.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Cobblestones3.png → /workspace/PixelWorld/assets/build/tiles/Cobblestones3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks1/Wood1.png → /workspace/PixelWorld/assets/build/tiles/Wood1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/DemonCastle2.png → /workspace/PixelWorld/assets/build/tiles/DemonCastle2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Castle1.png → /workspace/PixelWorld/assets/build/tiles/Castle1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Forest1.png → /workspace/PixelWorld/assets/build/tiles/Forest1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Crystal.png → /workspace/PixelWorld/assets/build/tiles/Crystal.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/RockCave.png → /workspace/PixelWorld/assets/build/tiles/RockCave.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Fort2.png → /workspace/PixelWorld/assets/build/tiles/Fort2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Fort1.png → /workspace/PixelWorld/assets/build/tiles/Fort1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Room2.png → /workspace/PixelWorld/assets/build/tiles/Room2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/PoisonSwamp.png → /workspace/PixelWorld/assets/build/tiles/PoisonSwamp.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Stone1.png → /workspace/PixelWorld/assets/build/tiles/Stone1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Stone5.png → /workspace/PixelWorld/assets/build/tiles/Stone5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Stone3.png → /workspace/PixelWorld/assets/build/tiles/Stone3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Tower.png → /workspace/PixelWorld/assets/build/tiles/Tower.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/DemonicWorld.png → /workspace/PixelWorld/assets/build/tiles/DemonicWorld.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/DirtCave.png → /workspace/PixelWorld/assets/build/tiles/DirtCave.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Port.png → /workspace/PixelWorld/assets/build/tiles/Port.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Stone2.png → /workspace/PixelWorld/assets/build/tiles/Stone2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Clouds.png → /workspace/PixelWorld/assets/build/tiles/Clouds.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/DarkSpace.png → /workspace/PixelWorld/assets/build/tiles/DarkSpace.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Castle2.png → /workspace/PixelWorld/assets/build/tiles/Castle2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Snowfield.png → /workspace/PixelWorld/assets/build/tiles/Snowfield.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Ship.png → /workspace/PixelWorld/assets/build/tiles/Ship.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Wasteland.png → /workspace/PixelWorld/assets/build/tiles/Wasteland.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Town4.png → /workspace/PixelWorld/assets/build/tiles/Town4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Sky.png → /workspace/PixelWorld/assets/build/tiles/Sky.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Sea.png → /workspace/PixelWorld/assets/build/tiles/Sea.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Factory.png → /workspace/PixelWorld/assets/build/tiles/Factory.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Brick.png → /workspace/PixelWorld/assets/build/tiles/Brick.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Mine.png → /workspace/PixelWorld/assets/build/tiles/Mine.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Town5.png → /workspace/PixelWorld/assets/build/tiles/Town5.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Castle3.png → /workspace/PixelWorld/assets/build/tiles/Castle3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Town2.png → /workspace/PixelWorld/assets/build/tiles/Town2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Town3.png → /workspace/PixelWorld/assets/build/tiles/Town3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Forest2.png → /workspace/PixelWorld/assets/build/tiles/Forest2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/IceMaze.png → /workspace/PixelWorld/assets/build/tiles/IceMaze.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Ruins.png → /workspace/PixelWorld/assets/build/tiles/Ruins.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/IceCave.png → /workspace/PixelWorld/assets/build/tiles/IceCave.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Lava.png → /workspace/PixelWorld/assets/build/tiles/Lava.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Town1.png → /workspace/PixelWorld/assets/build/tiles/Town1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Temple.png → /workspace/PixelWorld/assets/build/tiles/Temple.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Stone4.png → /workspace/PixelWorld/assets/build/tiles/Stone4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Tent.png → /workspace/PixelWorld/assets/build/tiles/Tent.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Room4.png → /workspace/PixelWorld/assets/build/tiles/Room4.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Grassland.png → /workspace/PixelWorld/assets/build/tiles/Grassland.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/LavaCave.png → /workspace/PixelWorld/assets/build/tiles/LavaCave.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Room1.png → /workspace/PixelWorld/assets/build/tiles/Room1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/GrassMaze.png → /workspace/PixelWorld/assets/build/tiles/GrassMaze.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/DemonCastle3.png → /workspace/PixelWorld/assets/build/tiles/DemonCastle3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Room3.png → /workspace/PixelWorld/assets/build/tiles/Room3.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/InBody.png → /workspace/PixelWorld/assets/build/tiles/InBody.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Bridge.png → /workspace/PixelWorld/assets/build/tiles/Bridge.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Desert.png → /workspace/PixelWorld/assets/build/tiles/Desert.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/DemonCastle1.png → /workspace/PixelWorld/assets/build/tiles/DemonCastle1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/tiles/battlebacks2/Cliff.png → /workspace/PixelWorld/assets/build/tiles/Cliff.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/system/Shadow.png → /workspace/PixelWorld/assets/build/ui/Shadow.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/system/IconSet.png → /workspace/PixelWorld/assets/build/ui/IconSet.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/system/BattleStart.png → /workspace/PixelWorld/assets/build/ui/BattleStart.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/system/Window.png → /workspace/PixelWorld/assets/build/ui/Window.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/system/Balloon.png → /workspace/PixelWorld/assets/build/ui/Balloon.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/system/GameOver.png → /workspace/PixelWorld/assets/build/ui/GameOver.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Tower2.png → /workspace/PixelWorld/assets/build/ui/Tower2.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Universe.png → /workspace/PixelWorld/assets/build/ui/Universe.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Dragon.png → /workspace/PixelWorld/assets/build/ui/Dragon.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Crystal.png → /workspace/PixelWorld/assets/build/ui/Crystal.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Island.png → /workspace/PixelWorld/assets/build/ui/Island.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Devil.png → /workspace/PixelWorld/assets/build/ui/Devil.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Tower1.png → /workspace/PixelWorld/assets/build/ui/Tower1.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/CrossedSwords.png → /workspace/PixelWorld/assets/build/ui/CrossedSwords.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Gates.png → /workspace/PixelWorld/assets/build/ui/Gates.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Castle.png → /workspace/PixelWorld/assets/build/ui/Castle.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Night.png → /workspace/PixelWorld/assets/build/ui/Night.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Sword.png → /workspace/PixelWorld/assets/build/ui/Sword.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Hexagram.png → /workspace/PixelWorld/assets/build/ui/Hexagram.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Book.png → /workspace/PixelWorld/assets/build/ui/Book.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Volcano.png → /workspace/PixelWorld/assets/build/ui/Volcano.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Fountain.png → /workspace/PixelWorld/assets/build/ui/Fountain.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/Plain.png → /workspace/PixelWorld/assets/build/ui/Plain.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/DemonCastle.png → /workspace/PixelWorld/assets/build/ui/DemonCastle.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/World.png → /workspace/PixelWorld/assets/build/ui/World.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles1/WorldMap.png → /workspace/PixelWorld/assets/build/ui/WorldMap.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Dragons.png → /workspace/PixelWorld/assets/build/ui/Dragons.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Fire.png → /workspace/PixelWorld/assets/build/ui/Fire.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Heroes.png → /workspace/PixelWorld/assets/build/ui/Heroes.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Mountains.png → /workspace/PixelWorld/assets/build/ui/Mountains.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Gargoyles.png → /workspace/PixelWorld/assets/build/ui/Gargoyles.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Forest.png → /workspace/PixelWorld/assets/build/ui/Forest.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Mist.png → /workspace/PixelWorld/assets/build/ui/Mist.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Metal.png → /workspace/PixelWorld/assets/build/ui/Metal.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/ui/titles2/Leaves.png → /workspace/PixelWorld/assets/build/ui/Leaves.png
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle9.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm11戦闘プレジデント・宝条.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm11戦闘プレジデント・宝条.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Field4.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Field4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm15Hお使い.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm15Hお使い.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Scene4.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Scene4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Town1.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Town1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm13H客.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm13H客.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Theme2.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Theme2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm09戦闘雑魚.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm09戦闘雑魚.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm17Hクラウド.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm17Hクラウド.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle2.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle3.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle7.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle6.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Town3.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Town3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Scene2.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Scene2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm02ステージ七番街スラム.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm02ステージ七番街スラム.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle5.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon1.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon8.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon3.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm05ステージ神羅飛空艇.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm05ステージ神羅飛空艇.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Field1.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Field1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm07ステージ神羅ビル.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm07ステージ神羅ビル.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Scene6.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Scene6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon7.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm12戦闘セフィロス.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm12戦闘セフィロス.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon4.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon6.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle1.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Theme4.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Theme4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm03ステージウォールマーケット.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm03ステージウォールマーケット.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm06ステージコレルプリズン.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm06ステージコレルプリズン.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm08ステージ神羅屋敷.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm08ステージ神羅屋敷.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Theme1.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Theme1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Town2.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Town2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Ship.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Ship.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm16H敗北.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm16H敗北.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle8.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm04ステージ弐番魔晄炉.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm04ステージ弐番魔晄炉.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon5.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Field3.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Field3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Town5.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Town5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Town4.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Town4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Field2.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Field2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Scene1.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Scene1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Town6.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Town6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm14H仲間.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm14H仲間.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm10戦闘中ボス.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm10戦闘中ボス.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon2.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Town7.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Town7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Battle4.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Battle4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Theme5.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Theme5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/bgm01ステージセブンスヘブン.mp3 → /workspace/PixelWorld/assets/build/audio/bgm/bgm01ステージセブンスヘブン.mp3
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Airship.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Airship.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Theme3.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Theme3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Scene3.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Scene3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Dungeon9.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Dungeon9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgm/Scene5.ogg → /workspace/PixelWorld/assets/build/audio/bgm/Scene5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Quake.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Quake.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Sea.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Sea.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Rain.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Rain.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Darkness.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Darkness.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Drips.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Drips.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Storm.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Storm.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Fire.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Fire.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Wind.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Wind.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/River.ogg → /workspace/PixelWorld/assets/build/audio/bgs/River.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/bgs/Clock.ogg → /workspace/PixelWorld/assets/build/audio/bgs/Clock.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Gameover1.ogg → /workspace/PixelWorld/assets/build/audio/me/Gameover1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Item.ogg → /workspace/PixelWorld/assets/build/audio/me/Item.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Organ.ogg → /workspace/PixelWorld/assets/build/audio/me/Organ.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Gameover2.ogg → /workspace/PixelWorld/assets/build/audio/me/Gameover2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Fanfare3.ogg → /workspace/PixelWorld/assets/build/audio/me/Fanfare3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Mystery.ogg → /workspace/PixelWorld/assets/build/audio/me/Mystery.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Victory2.ogg → /workspace/PixelWorld/assets/build/audio/me/Victory2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Inn.ogg → /workspace/PixelWorld/assets/build/audio/me/Inn.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Fanfare1.ogg → /workspace/PixelWorld/assets/build/audio/me/Fanfare1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Shock.ogg → /workspace/PixelWorld/assets/build/audio/me/Shock.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Fanfare2.ogg → /workspace/PixelWorld/assets/build/audio/me/Fanfare2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Victory1.ogg → /workspace/PixelWorld/assets/build/audio/me/Victory1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/me/Gag.ogg → /workspace/PixelWorld/assets/build/audio/me/Gag.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv31.ogg → /workspace/PixelWorld/assets/build/audio/se/cv31.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Dog.ogg → /workspace/PixelWorld/assets/build/audio/se/Dog.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth3.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv58.ogg → /workspace/PixelWorld/assets/build/audio/se/cv58.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv19.ogg → /workspace/PixelWorld/assets/build/audio/se/cv19.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sword5.ogg → /workspace/PixelWorld/assets/build/audio/se/Sword5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Barrier.ogg → /workspace/PixelWorld/assets/build/audio/se/Barrier.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Explosion5.ogg → /workspace/PixelWorld/assets/build/audio/se/Explosion5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow8.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Shot2.ogg → /workspace/PixelWorld/assets/build/audio/se/Shot2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder7.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Skill3.ogg → /workspace/PixelWorld/assets/build/audio/se/Skill3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder5.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv57.ogg → /workspace/PixelWorld/assets/build/audio/se/cv57.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cow.ogg → /workspace/PixelWorld/assets/build/audio/se/Cow.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Water1.ogg → /workspace/PixelWorld/assets/build/audio/se/Water1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Raise3.ogg → /workspace/PixelWorld/assets/build/audio/se/Raise3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Scream.ogg → /workspace/PixelWorld/assets/build/audio/se/Scream.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint7.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Raise1.ogg → /workspace/PixelWorld/assets/build/audio/se/Raise1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv47.ogg → /workspace/PixelWorld/assets/build/audio/se/cv47.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Switch3.ogg → /workspace/PixelWorld/assets/build/audio/se/Switch3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow6.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Chest.ogg → /workspace/PixelWorld/assets/build/audio/se/Chest.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Crow.ogg → /workspace/PixelWorld/assets/build/audio/se/Crow.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice4.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv35.ogg → /workspace/PixelWorld/assets/build/audio/se/cv35.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Explosion2.ogg → /workspace/PixelWorld/assets/build/audio/se/Explosion2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice6.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/ミッションクリア.ogg → /workspace/PixelWorld/assets/build/audio/se/ミッションクリア.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv59.ogg → /workspace/PixelWorld/assets/build/audio/se/cv59.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Absorb1.ogg → /workspace/PixelWorld/assets/build/audio/se/Absorb1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv03.ogg → /workspace/PixelWorld/assets/build/audio/se/cv03.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow2.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv05.ogg → /workspace/PixelWorld/assets/build/audio/se/cv05.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Buzzer1.ogg → /workspace/PixelWorld/assets/build/audio/se/Buzzer1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Powerup.ogg → /workspace/PixelWorld/assets/build/audio/se/Powerup.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bow3.ogg → /workspace/PixelWorld/assets/build/audio/se/Bow3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Save.ogg → /workspace/PixelWorld/assets/build/audio/se/Save.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Decision1.ogg → /workspace/PixelWorld/assets/build/audio/se/Decision1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Attack3.ogg → /workspace/PixelWorld/assets/build/audio/se/Attack3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Applause2.ogg → /workspace/PixelWorld/assets/build/audio/se/Applause2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Monster6.ogg → /workspace/PixelWorld/assets/build/audio/se/Monster6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv21.ogg → /workspace/PixelWorld/assets/build/audio/se/cv21.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv07.ogg → /workspace/PixelWorld/assets/build/audio/se/cv07.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Buzzer2.ogg → /workspace/PixelWorld/assets/build/audio/se/Buzzer2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Explosion4.ogg → /workspace/PixelWorld/assets/build/audio/se/Explosion4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Battle2.ogg → /workspace/PixelWorld/assets/build/audio/se/Battle2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice9.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Damage1.ogg → /workspace/PixelWorld/assets/build/audio/se/Damage1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sound1.ogg → /workspace/PixelWorld/assets/build/audio/se/Sound1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv13.ogg → /workspace/PixelWorld/assets/build/audio/se/cv13.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Battle3.ogg → /workspace/PixelWorld/assets/build/audio/se/Battle3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Heal6.ogg → /workspace/PixelWorld/assets/build/audio/se/Heal6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Close1.ogg → /workspace/PixelWorld/assets/build/audio/se/Close1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Item2.ogg → /workspace/PixelWorld/assets/build/audio/se/Item2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sword1.ogg → /workspace/PixelWorld/assets/build/audio/se/Sword1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv44.ogg → /workspace/PixelWorld/assets/build/audio/se/cv44.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash5.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire1.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Damage5.ogg → /workspace/PixelWorld/assets/build/audio/se/Damage5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Paralyze3.ogg → /workspace/PixelWorld/assets/build/audio/se/Paralyze3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth7.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint9.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Open2.ogg → /workspace/PixelWorld/assets/build/audio/se/Open2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth2.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Explosion1.ogg → /workspace/PixelWorld/assets/build/audio/se/Explosion1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Collapse4.ogg → /workspace/PixelWorld/assets/build/audio/se/Collapse4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness3.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Water6.ogg → /workspace/PixelWorld/assets/build/audio/se/Water6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sleep.ogg → /workspace/PixelWorld/assets/build/audio/se/Sleep.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Monster1.ogg → /workspace/PixelWorld/assets/build/audio/se/Monster1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint4.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder8.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv01.ogg → /workspace/PixelWorld/assets/build/audio/se/cv01.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Collapse1.ogg → /workspace/PixelWorld/assets/build/audio/se/Collapse1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind11.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind11.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/宝箱.ogg → /workspace/PixelWorld/assets/build/audio/se/宝箱.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind10.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind10.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash2.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Decision3.ogg → /workspace/PixelWorld/assets/build/audio/se/Decision3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv42.ogg → /workspace/PixelWorld/assets/build/audio/se/cv42.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Down1.ogg → /workspace/PixelWorld/assets/build/audio/se/Down1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv18.ogg → /workspace/PixelWorld/assets/build/audio/se/cv18.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Attack1.ogg → /workspace/PixelWorld/assets/build/audio/se/Attack1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv38.ogg → /workspace/PixelWorld/assets/build/audio/se/cv38.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint1.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv50.ogg → /workspace/PixelWorld/assets/build/audio/se/cv50.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Magic5.ogg → /workspace/PixelWorld/assets/build/audio/se/Magic5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder9.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv48.ogg → /workspace/PixelWorld/assets/build/audio/se/cv48.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sound2.ogg → /workspace/PixelWorld/assets/build/audio/se/Sound2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire5.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Up2.ogg → /workspace/PixelWorld/assets/build/audio/se/Up2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Book2.ogg → /workspace/PixelWorld/assets/build/audio/se/Book2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Poison.ogg → /workspace/PixelWorld/assets/build/audio/se/Poison.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth8.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Open5.ogg → /workspace/PixelWorld/assets/build/audio/se/Open5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Shop.ogg → /workspace/PixelWorld/assets/build/audio/se/Shop.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Teleport.ogg → /workspace/PixelWorld/assets/build/audio/se/Teleport.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv54.ogg → /workspace/PixelWorld/assets/build/audio/se/cv54.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice2.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness5.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fall.ogg → /workspace/PixelWorld/assets/build/audio/se/Fall.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Disappointment.ogg → /workspace/PixelWorld/assets/build/audio/se/Disappointment.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Dive.ogg → /workspace/PixelWorld/assets/build/audio/se/Dive.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Crash.ogg → /workspace/PixelWorld/assets/build/audio/se/Crash.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Heal1.ogg → /workspace/PixelWorld/assets/build/audio/se/Heal1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv64.ogg → /workspace/PixelWorld/assets/build/audio/se/cv64.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv52.ogg → /workspace/PixelWorld/assets/build/audio/se/cv52.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bell1.ogg → /workspace/PixelWorld/assets/build/audio/se/Bell1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash10.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash10.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Phone.ogg → /workspace/PixelWorld/assets/build/audio/se/Phone.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness4.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice10.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice10.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv10.ogg → /workspace/PixelWorld/assets/build/audio/se/cv10.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Jump2.ogg → /workspace/PixelWorld/assets/build/audio/se/Jump2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Chime1.ogg → /workspace/PixelWorld/assets/build/audio/se/Chime1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sheep.ogg → /workspace/PixelWorld/assets/build/audio/se/Sheep.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Shot1.ogg → /workspace/PixelWorld/assets/build/audio/se/Shot1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Noise.ogg → /workspace/PixelWorld/assets/build/audio/se/Noise.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv56.ogg → /workspace/PixelWorld/assets/build/audio/se/cv56.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bell2.ogg → /workspace/PixelWorld/assets/build/audio/se/Bell2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Attack2.ogg → /workspace/PixelWorld/assets/build/audio/se/Attack2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Explosion6.ogg → /workspace/PixelWorld/assets/build/audio/se/Explosion6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder11.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder11.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash11.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash11.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv45.ogg → /workspace/PixelWorld/assets/build/audio/se/cv45.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow4.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Paralyze2.ogg → /workspace/PixelWorld/assets/build/audio/se/Paralyze2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash7.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Magic4.ogg → /workspace/PixelWorld/assets/build/audio/se/Magic4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Close3.ogg → /workspace/PixelWorld/assets/build/audio/se/Close3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Book1.ogg → /workspace/PixelWorld/assets/build/audio/se/Book1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Switch1.ogg → /workspace/PixelWorld/assets/build/audio/se/Switch1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Switch2.ogg → /workspace/PixelWorld/assets/build/audio/se/Switch2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Close2.ogg → /workspace/PixelWorld/assets/build/audio/se/Close2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth9.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint6.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice8.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash3.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint5.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Break.ogg → /workspace/PixelWorld/assets/build/audio/se/Break.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder2.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Down3.ogg → /workspace/PixelWorld/assets/build/audio/se/Down3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Up3.ogg → /workspace/PixelWorld/assets/build/audio/se/Up3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Water4.ogg → /workspace/PixelWorld/assets/build/audio/se/Water4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Machine.ogg → /workspace/PixelWorld/assets/build/audio/se/Machine.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire6.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Shot3.ogg → /workspace/PixelWorld/assets/build/audio/se/Shot3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Flash3.ogg → /workspace/PixelWorld/assets/build/audio/se/Flash3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Water3.ogg → /workspace/PixelWorld/assets/build/audio/se/Water3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder3.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire3.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv60.ogg → /workspace/PixelWorld/assets/build/audio/se/cv60.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Jump1.ogg → /workspace/PixelWorld/assets/build/audio/se/Jump1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv37.ogg → /workspace/PixelWorld/assets/build/audio/se/cv37.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth4.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire7.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint8.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Starlight.ogg → /workspace/PixelWorld/assets/build/audio/se/Starlight.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire8.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder10.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder10.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Hammer.ogg → /workspace/PixelWorld/assets/build/audio/se/Hammer.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Magic1.ogg → /workspace/PixelWorld/assets/build/audio/se/Magic1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sand.ogg → /workspace/PixelWorld/assets/build/audio/se/Sand.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv20.ogg → /workspace/PixelWorld/assets/build/audio/se/cv20.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Autodoor.ogg → /workspace/PixelWorld/assets/build/audio/se/Autodoor.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Stare.ogg → /workspace/PixelWorld/assets/build/audio/se/Stare.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Magic6.ogg → /workspace/PixelWorld/assets/build/audio/se/Magic6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Equip1.ogg → /workspace/PixelWorld/assets/build/audio/se/Equip1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Knock.ogg → /workspace/PixelWorld/assets/build/audio/se/Knock.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint2.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Explosion7.ogg → /workspace/PixelWorld/assets/build/audio/se/Explosion7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness1.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Run.ogg → /workspace/PixelWorld/assets/build/audio/se/Run.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv51.ogg → /workspace/PixelWorld/assets/build/audio/se/cv51.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire4.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv24.ogg → /workspace/PixelWorld/assets/build/audio/se/cv24.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Up4.ogg → /workspace/PixelWorld/assets/build/audio/se/Up4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow5.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness8.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind4.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv33.ogg → /workspace/PixelWorld/assets/build/audio/se/cv33.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow7.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness6.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Water5.ogg → /workspace/PixelWorld/assets/build/audio/se/Water5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness2.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Chime2.ogg → /workspace/PixelWorld/assets/build/audio/se/Chime2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Devil2.ogg → /workspace/PixelWorld/assets/build/audio/se/Devil2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Gun2.ogg → /workspace/PixelWorld/assets/build/audio/se/Gun2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Reflection.ogg → /workspace/PixelWorld/assets/build/audio/se/Reflection.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Battle1.ogg → /workspace/PixelWorld/assets/build/audio/se/Battle1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv30.ogg → /workspace/PixelWorld/assets/build/audio/se/cv30.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Confuse.ogg → /workspace/PixelWorld/assets/build/audio/se/Confuse.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv29.ogg → /workspace/PixelWorld/assets/build/audio/se/cv29.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash1.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind6.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sound3.ogg → /workspace/PixelWorld/assets/build/audio/se/Sound3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder12.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder12.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bell3.ogg → /workspace/PixelWorld/assets/build/audio/se/Bell3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Damage4.ogg → /workspace/PixelWorld/assets/build/audio/se/Damage4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv43.ogg → /workspace/PixelWorld/assets/build/audio/se/cv43.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv25.ogg → /workspace/PixelWorld/assets/build/audio/se/cv25.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Parry.ogg → /workspace/PixelWorld/assets/build/audio/se/Parry.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Monster7.ogg → /workspace/PixelWorld/assets/build/audio/se/Monster7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice5.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash9.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Paralyze1.ogg → /workspace/PixelWorld/assets/build/audio/se/Paralyze1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sword2.ogg → /workspace/PixelWorld/assets/build/audio/se/Sword2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sword3.ogg → /workspace/PixelWorld/assets/build/audio/se/Sword3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Chicken.ogg → /workspace/PixelWorld/assets/build/audio/se/Chicken.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv34.ogg → /workspace/PixelWorld/assets/build/audio/se/cv34.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash12.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash12.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Devil1.ogg → /workspace/PixelWorld/assets/build/audio/se/Devil1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Resonance.ogg → /workspace/PixelWorld/assets/build/audio/se/Resonance.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Damage3.ogg → /workspace/PixelWorld/assets/build/audio/se/Damage3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv40.ogg → /workspace/PixelWorld/assets/build/audio/se/cv40.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Decision2.ogg → /workspace/PixelWorld/assets/build/audio/se/Decision2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Push.ogg → /workspace/PixelWorld/assets/build/audio/se/Push.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv08.ogg → /workspace/PixelWorld/assets/build/audio/se/cv08.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind7.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Heal2.ogg → /workspace/PixelWorld/assets/build/audio/se/Heal2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Equip2.ogg → /workspace/PixelWorld/assets/build/audio/se/Equip2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth5.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cry1.ogg → /workspace/PixelWorld/assets/build/audio/se/Cry1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice3.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Item1.ogg → /workspace/PixelWorld/assets/build/audio/se/Item1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bow1.ogg → /workspace/PixelWorld/assets/build/audio/se/Bow1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Evasion2.ogg → /workspace/PixelWorld/assets/build/audio/se/Evasion2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder1.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind2.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv32.ogg → /workspace/PixelWorld/assets/build/audio/se/cv32.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Gun1.ogg → /workspace/PixelWorld/assets/build/audio/se/Gun1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Skill1.ogg → /workspace/PixelWorld/assets/build/audio/se/Skill1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Open3.ogg → /workspace/PixelWorld/assets/build/audio/se/Open3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Down2.ogg → /workspace/PixelWorld/assets/build/audio/se/Down2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire9.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Breath.ogg → /workspace/PixelWorld/assets/build/audio/se/Breath.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv28.ogg → /workspace/PixelWorld/assets/build/audio/se/cv28.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Darkness7.ogg → /workspace/PixelWorld/assets/build/audio/se/Darkness7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Heal7.ogg → /workspace/PixelWorld/assets/build/audio/se/Heal7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind3.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Sword4.ogg → /workspace/PixelWorld/assets/build/audio/se/Sword4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Up1.ogg → /workspace/PixelWorld/assets/build/audio/se/Up1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bite.ogg → /workspace/PixelWorld/assets/build/audio/se/Bite.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Pollen.ogg → /workspace/PixelWorld/assets/build/audio/se/Pollen.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blind.ogg → /workspace/PixelWorld/assets/build/audio/se/Blind.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cancel1.ogg → /workspace/PixelWorld/assets/build/audio/se/Cancel1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth1.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv55.ogg → /workspace/PixelWorld/assets/build/audio/se/cv55.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv46.ogg → /workspace/PixelWorld/assets/build/audio/se/cv46.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cry2.ogg → /workspace/PixelWorld/assets/build/audio/se/Cry2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv09.ogg → /workspace/PixelWorld/assets/build/audio/se/cv09.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv16.ogg → /workspace/PixelWorld/assets/build/audio/se/cv16.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv41.ogg → /workspace/PixelWorld/assets/build/audio/se/cv41.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder4.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind8.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Devil3.ogg → /workspace/PixelWorld/assets/build/audio/se/Devil3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv49.ogg → /workspace/PixelWorld/assets/build/audio/se/cv49.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv15.ogg → /workspace/PixelWorld/assets/build/audio/se/cv15.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Thunder6.ogg → /workspace/PixelWorld/assets/build/audio/se/Thunder6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Skill2.ogg → /workspace/PixelWorld/assets/build/audio/se/Skill2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv26.ogg → /workspace/PixelWorld/assets/build/audio/se/cv26.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv27.ogg → /workspace/PixelWorld/assets/build/audio/se/cv27.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv22.ogg → /workspace/PixelWorld/assets/build/audio/se/cv22.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Down4.ogg → /workspace/PixelWorld/assets/build/audio/se/Down4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Laser.ogg → /workspace/PixelWorld/assets/build/audio/se/Laser.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Evasion1.ogg → /workspace/PixelWorld/assets/build/audio/se/Evasion1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Saint3.ogg → /workspace/PixelWorld/assets/build/audio/se/Saint3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Heal3.ogg → /workspace/PixelWorld/assets/build/audio/se/Heal3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fog1.ogg → /workspace/PixelWorld/assets/build/audio/se/Fog1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Load.ogg → /workspace/PixelWorld/assets/build/audio/se/Load.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Raise2.ogg → /workspace/PixelWorld/assets/build/audio/se/Raise2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice7.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv36.ogg → /workspace/PixelWorld/assets/build/audio/se/cv36.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bow2.ogg → /workspace/PixelWorld/assets/build/audio/se/Bow2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind5.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Magic2.ogg → /workspace/PixelWorld/assets/build/audio/se/Magic2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cancel2.ogg → /workspace/PixelWorld/assets/build/audio/se/Cancel2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Move.ogg → /workspace/PixelWorld/assets/build/audio/se/Move.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Silence.ogg → /workspace/PixelWorld/assets/build/audio/se/Silence.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Key.ogg → /workspace/PixelWorld/assets/build/audio/se/Key.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Coin.ogg → /workspace/PixelWorld/assets/build/audio/se/Coin.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Earth6.ogg → /workspace/PixelWorld/assets/build/audio/se/Earth6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Crossbow.ogg → /workspace/PixelWorld/assets/build/audio/se/Crossbow.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fire2.ogg → /workspace/PixelWorld/assets/build/audio/se/Fire2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind1.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Collapse3.ogg → /workspace/PixelWorld/assets/build/audio/se/Collapse3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice11.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice11.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow3.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Magic3.ogg → /workspace/PixelWorld/assets/build/audio/se/Magic3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wind9.ogg → /workspace/PixelWorld/assets/build/audio/se/Wind9.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cursor2.ogg → /workspace/PixelWorld/assets/build/audio/se/Cursor2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv04.ogg → /workspace/PixelWorld/assets/build/audio/se/cv04.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv23.ogg → /workspace/PixelWorld/assets/build/audio/se/cv23.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cat.ogg → /workspace/PixelWorld/assets/build/audio/se/Cat.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Heal5.ogg → /workspace/PixelWorld/assets/build/audio/se/Heal5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash4.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Miss.ogg → /workspace/PixelWorld/assets/build/audio/se/Miss.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv11.ogg → /workspace/PixelWorld/assets/build/audio/se/cv11.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Horse.ogg → /workspace/PixelWorld/assets/build/audio/se/Horse.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Flash1.ogg → /workspace/PixelWorld/assets/build/audio/se/Flash1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Open1.ogg → /workspace/PixelWorld/assets/build/audio/se/Open1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Explosion3.ogg → /workspace/PixelWorld/assets/build/audio/se/Explosion3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Magic7.ogg → /workspace/PixelWorld/assets/build/audio/se/Magic7.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Blow1.ogg → /workspace/PixelWorld/assets/build/audio/se/Blow1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Item3.ogg → /workspace/PixelWorld/assets/build/audio/se/Item3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Cursor1.ogg → /workspace/PixelWorld/assets/build/audio/se/Cursor1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv14.ogg → /workspace/PixelWorld/assets/build/audio/se/cv14.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Flash2.ogg → /workspace/PixelWorld/assets/build/audio/se/Flash2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Monster5.ogg → /workspace/PixelWorld/assets/build/audio/se/Monster5.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Collapse2.ogg → /workspace/PixelWorld/assets/build/audio/se/Collapse2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv39.ogg → /workspace/PixelWorld/assets/build/audio/se/cv39.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv17.ogg → /workspace/PixelWorld/assets/build/audio/se/cv17.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Absorb2.ogg → /workspace/PixelWorld/assets/build/audio/se/Absorb2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash6.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash6.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Monster2.ogg → /workspace/PixelWorld/assets/build/audio/se/Monster2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Fog2.ogg → /workspace/PixelWorld/assets/build/audio/se/Fog2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Applause1.ogg → /workspace/PixelWorld/assets/build/audio/se/Applause1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv53.ogg → /workspace/PixelWorld/assets/build/audio/se/cv53.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Damage2.ogg → /workspace/PixelWorld/assets/build/audio/se/Damage2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Ice1.ogg → /workspace/PixelWorld/assets/build/audio/se/Ice1.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Open4.ogg → /workspace/PixelWorld/assets/build/audio/se/Open4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv12.ogg → /workspace/PixelWorld/assets/build/audio/se/cv12.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv06.ogg → /workspace/PixelWorld/assets/build/audio/se/cv06.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Equip3.ogg → /workspace/PixelWorld/assets/build/audio/se/Equip3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Monster4.ogg → /workspace/PixelWorld/assets/build/audio/se/Monster4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Recovery.ogg → /workspace/PixelWorld/assets/build/audio/se/Recovery.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Bow4.ogg → /workspace/PixelWorld/assets/build/audio/se/Bow4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Slash8.ogg → /workspace/PixelWorld/assets/build/audio/se/Slash8.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Heal4.ogg → /workspace/PixelWorld/assets/build/audio/se/Heal4.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Monster3.ogg → /workspace/PixelWorld/assets/build/audio/se/Monster3.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Water2.ogg → /workspace/PixelWorld/assets/build/audio/se/Water2.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/cv02.ogg → /workspace/PixelWorld/assets/build/audio/se/cv02.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Twine.ogg → /workspace/PixelWorld/assets/build/audio/se/Twine.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Frog.ogg → /workspace/PixelWorld/assets/build/audio/se/Frog.ogg
+[OK]  Copied: /workspace/PixelWorld/assets/user_imports/audio/se/Wolf.ogg → /workspace/PixelWorld/assets/build/audio/se/Wolf.ogg
+[INFO] Found 420 audio files, 429 image files
+[INFO] Wrote index: /workspace/PixelWorld/assets/build/index.json
+[DONE] Import finished without binary generation.

--- a/scripts/import_user_assets.py
+++ b/scripts/import_user_assets.py
@@ -1,206 +1,250 @@
 #!/usr/bin/env python3
-"""Synchronise user-supplied assets into the shared build directory.
+# 严禁生成二进制文件，此脚本仅处理文本记录与复制或移动已存在的文件
+"""导入用户素材到统一 build 目录的脚本。"""
 
-This script is intentionally limited to *textual* operations.  It never
-encodes, compresses, or transforms binary payloads; instead it simply copies the
-files that already exist within the repository.  The workflow is:
+from __future__ import annotations  # 保证类型提示前向引用，纯文本操作
 
-1. Validate that the expected top-level categories exist beneath
-   ``assets/user_imports``.
-2. Mirror the directory structure into ``assets/build`` using ``shutil.copy2``
-   (which preserves timestamps without decoding the file contents).
-3. Produce a lightweight ``asset_index.json`` file that records the relative
-   path, size, and modification timestamp for every imported file.
-4. Append a log entry to ``logs/user_imports.log`` and emit a success message
-   to ``stdout`` so automated jobs can assert completion.
+import argparse  # 解析命令行参数
+import json  # 处理 JSON 文本
+import logging  # 记录日志到文本文件
+import shutil  # 执行复制或移动操作但不生成二进制
+from datetime import datetime, timezone  # 生成 UTC 时间戳
+from pathlib import Path  # 进行路径运算
+from typing import Dict, List, Optional, Tuple  # 类型提示辅助
 
-The command accepts an optional ``--root`` argument so that CI pipelines can run
-it from arbitrary working directories.  All paths are resolved relative to the
-repository root, and only the Python standard library is required.
-"""
-
-from __future__ import annotations
-
-import argparse
-import json
-import logging
-import shutil
-from datetime import datetime, timezone
-from pathlib import Path
-from typing import Dict, Iterable, List
-
-# Allowed directory names inside ``assets/user_imports``.  Keeping this list
-# explicit ensures that accidental folders do not leak into ``assets/build``.
-ALLOWED_TOP_LEVEL = {
-    'audio',
-    'characters',
-    'tiles',
-    'ui',
-    'effects',
+# 默认规则映射，键为用户素材目录，值为 build 下的目标相对路径
+DEFAULT_RULES: Dict[str, str] = {
+    "audio/bgm": "audio/bgm",  # 背景音乐归类
+    "audio/bgs": "audio/bgs",  # 背景环境音归类
+    "audio/me": "audio/me",  # 事件音乐归类
+    "audio/se": "audio/se",  # 音效归类
+    "graphics/characters": "characters",  # 角色图归类
+    "graphics/animations": "effects",  # 动画特效归类
+    "graphics/battlebacks1": "tiles",  # 战斗背景推送至瓦片
+    "graphics/battlebacks2": "tiles",  # 战斗背景推送至瓦片
+    "graphics/tilesets": "tiles",  # 瓦片集归类
+    "graphics/parallaxes": "tiles",  # 视差图归类
+    "characters": "characters",  # 兼容旧结构
+    "tiles": "tiles",  # 兼容旧结构
+    "effects": "effects",  # 兼容旧结构
+    "ui": "ui",  # 兼容旧结构
 }
 
-# Files that live directly under assets/user_imports/ but are not copied into
-# the build directory.
-ALLOWED_TOP_LEVEL_FILES = {'README.md', 'user_manifest.json'}
-
-# ``audio`` has a fixed set of sub-categories.  The script verifies these to
-# keep naming consistent with the MiniWorld runtime.
-ALLOWED_AUDIO_SUBDIRS = {'bgm', 'bgs', 'me', 'se'}
-
-LOG_FORMAT = '[%(asctime)s] %(levelname)s %(message)s'
+# 图像二级分类关键字，用于未匹配目录时简单判断
+TILE_KEYWORDS = ["tile", "battleback", "parallax", "world", "map"]  # 判定为瓦片
+UI_KEYWORDS = ["icon", "ui", "menu", "button", "cursor"]  # 判定为界面
 
 
-def configure_logger(log_path: Path) -> logging.Logger:
-    """Configure a file-and-console logger."""
+def load_rules(rule_path: Optional[Path]) -> Dict[str, str]:
+    """载入自定义规则，若不存在则返回默认规则副本。"""
 
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    logger = logging.getLogger('user-imports')
-    logger.setLevel(logging.INFO)
-    logger.handlers.clear()
+    if rule_path is None:  # 未提供规则文件
+        return {key.lower(): value for key, value in DEFAULT_RULES.items()}  # 返回默认规则副本
+    if not rule_path.exists():  # 文件不存在时报错
+        raise FileNotFoundError(f"规则文件不存在: {rule_path}")  # 抛出异常
+    with rule_path.open("r", encoding="utf-8") as handle:  # 读取 JSON 文本
+        data = json.load(handle)  # 解析 JSON 内容
+    merged = dict(DEFAULT_RULES)  # 复制默认规则
+    merged.update({str(k).lower(): str(v) for k, v in data.items()})  # 合并自定义规则
+    return {key.lower(): value for key, value in merged.items()}  # 返回小写键映射
 
-    formatter = logging.Formatter(LOG_FORMAT)
 
-    file_handler = logging.FileHandler(log_path, encoding='utf-8')
-    file_handler.setFormatter(formatter)
-    logger.addHandler(file_handler)
+def classify_graphics(sub_path: Path, logger: logging.Logger) -> str:
+    """根据图形子目录名称推断目标分类。"""
 
-    stream_handler = logging.StreamHandler()
-    stream_handler.setFormatter(formatter)
-    logger.addHandler(stream_handler)
+    name = sub_path.name.lower()  # 取小写目录名
+    if any(keyword in name for keyword in TILE_KEYWORDS):  # 包含瓦片关键字
+        logger.warning("[WARN] 未识别目录 %s → 归入 build/tiles", sub_path)  # 记录警告
+        return "tiles"  # 返回瓦片分类
+    if any(keyword in name for keyword in UI_KEYWORDS):  # 包含界面关键字
+        logger.warning("[WARN] 未识别目录 %s → 归入 build/ui", sub_path)  # 记录警告
+        return "ui"  # 返回界面分类
+    logger.warning("[WARN] 未识别目录 %s → 默认归入 build/ui", sub_path)  # 无匹配则归入 UI
+    return "ui"  # 默认返回界面分类
 
-    return logger
+
+def determine_target(
+    relative: Path,
+    rules: Dict[str, str],
+    logger: logging.Logger,
+) -> Optional[Tuple[str, str]]:
+    """根据规则确定目标子目录与索引类别。"""
+
+    parts = relative.parts  # 拆分路径片段
+    if not parts:  # 若没有有效片段
+        logger.error("[ERROR] 空路径无法处理: %s", relative)  # 记录错误
+        return None  # 返回空
+    first = parts[0].lower()  # 第一层目录
+    second = parts[1].lower() if len(parts) > 1 else ""  # 第二层目录
+    candidates = []  # 候选键集合
+    if second:  # 若存在二级目录
+        candidates.append(f"{first}/{second}")  # 加入组合键
+    candidates.append(first)  # 加入一级目录键
+    if len(parts) > 1:  # 兼容原始大小写键
+        candidates.append(f"{parts[0]}/{parts[1]}".lower())  # 加入原始组合键的小写形式
+    for candidate in candidates:  # 遍历候选键
+        if candidate in rules:  # 若命中规则
+            target_dir = rules[candidate]  # 获取目标目录
+            category_key = target_dir.split("/")[-1]  # 提取类别键
+            return target_dir, category_key  # 返回映射
+    if first == "graphics" and len(parts) > 1:  # 处理图像未匹配目录
+        fallback = classify_graphics(Path(parts[1]), logger)  # 使用分类器
+        return fallback, fallback  # 返回 fallback 分类
+    logger.warning("[WARN] 未匹配的目录 %s 已跳过", relative)  # 其余情况跳过
+    return None  # 返回空
+
+
+def ensure_directory(path: Path) -> None:
+    """确保目标目录存在。"""
+
+    path.mkdir(parents=True, exist_ok=True)  # 创建目录（若已存在不会报错）
+
+
+def copy_or_move(src: Path, dst: Path, move: bool) -> None:
+    """根据模式复制或移动文件，若已存在则覆盖。"""
+
+    if dst.exists():  # 若目标已存在
+        if dst.is_file():  # 仅对文件执行删除
+            dst.unlink()  # 删除旧文件
+    if move:  # 移动模式
+        shutil.move(str(src), str(dst))  # 移动文件
+    else:  # 复制模式
+        shutil.copy2(src, dst)  # 复制文件
+
+
+def gather_user_files(user_root: Path) -> List[Path]:
+    """收集用户素材目录下的所有文件。"""
+
+    if not user_root.exists():  # 若目录不存在
+        raise FileNotFoundError(f"用户素材目录不存在: {user_root}")  # 抛出异常
+    return [path for path in user_root.rglob("*") if path.is_file()]  # 返回所有文件路径
+
+
+def build_index_structure() -> Dict[str, Dict[str, List[str]]]:
+    """初始化索引结构。"""
+
+    return {
+        "audio": {"bgm": [], "bgs": [], "me": [], "se": []},  # 音频分类
+        "images": {"characters": [], "tiles": [], "effects": [], "ui": []},  # 图像分类
+    }
+
+
+def update_index(
+    index: Dict[str, Dict[str, List[str]]],
+    category: str,
+    subcategory: str,
+    relative_path: str,
+) -> None:
+    """向索引结构中追加条目。"""
+
+    container = index.get(category, {})  # 获取一级分类容器
+    if subcategory not in container:  # 若不存在子分类
+        container[subcategory] = []  # 初始化子分类列表
+    if relative_path not in container[subcategory]:  # 避免重复
+        container[subcategory].append(relative_path)  # 追加路径
+
+
+def run_import(
+    root: Path,
+    move_mode: bool = False,
+    rule_file: Optional[Path] = None,
+) -> Dict[str, Dict[str, List[str]]]:
+    """执行导入流程并返回索引结构。"""
+
+    assets_root = root / "assets"  # 资产根目录
+    user_root = assets_root / "user_imports"  # 用户素材目录
+    build_root = assets_root / "build"  # build 目录
+    log_root = root / "logs"  # 日志目录
+    ensure_directory(log_root)  # 确保日志目录存在
+    logger = logging.getLogger("user_imports")  # 获取日志记录器
+    logger.setLevel(logging.INFO)  # 设置日志等级
+    log_path = log_root / "user_imports.log"  # 日志文件路径
+    handler = logging.FileHandler(log_path, encoding="utf-8")  # 创建文件处理器
+    formatter = logging.Formatter("%(message)s")  # 定义输出格式
+    handler.setFormatter(formatter)  # 设置格式化器
+    logger.handlers = [handler]  # 替换旧处理器确保幂等
+    mode_label = "move" if move_mode else "copy"  # 记录模式标签
+    rules = load_rules(rule_file)  # 加载规则
+    logger.info("[INFO] Start import (%s mode). Rules = %s", mode_label, rule_file or "default")  # 写入日志
+    files = gather_user_files(user_root)  # 收集用户文件
+    audio_count = 0  # 统计音频数量
+    image_count = 0  # 统计图像数量
+    index_data = build_index_structure()  # 初始化索引
+    for path in files:  # 遍历每个文件
+        relative = path.relative_to(user_root)  # 计算相对路径
+        mapping = determine_target(relative, rules, logger)  # 判断目标目录
+        if not mapping:  # 若无法映射
+            continue  # 跳过
+        target_dir_name, category_key = mapping  # 解包目标信息
+        if target_dir_name.startswith("audio/"):  # 音频类
+            category = "audio"  # 一级分类
+            if category_key not in index_data[category]:  # 若子分类未初始化
+                index_data[category][category_key] = []  # 初始化空列表
+            audio_count += 1  # 增加计数
+        else:  # 图像类
+            category = "images"  # 一级分类
+            if category_key not in index_data[category]:  # 若子分类未初始化
+                index_data[category][category_key] = []  # 初始化空列表
+            image_count += 1  # 增加计数
+        destination_dir = build_root / target_dir_name  # 计算目标目录路径
+        ensure_directory(destination_dir)  # 确保目录存在
+        destination_file = destination_dir / path.name  # 目标文件路径
+        copy_or_move(path, destination_file, move_mode)  # 执行复制或移动
+        relative_record = destination_file.relative_to(build_root).as_posix()  # 相对路径记录
+        update_index(index_data, category, category_key, relative_record)  # 更新索引
+        logger.info(
+            "[OK]  %s: %s → %s",
+            "Moved" if move_mode else "Copied",  # 记录动作
+            path.as_posix(),  # 源路径
+            destination_file.as_posix(),  # 目标路径
+        )
+    logger.info("[INFO] Found %s audio files, %s image files", audio_count, image_count)  # 统计日志
+    index_payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),  # 生成时间
+        "sources": "assets/user_imports/",  # 数据源说明
+        "audio": index_data["audio"],  # 音频索引
+        "images": index_data["images"],  # 图像索引
+        "notes": [
+            "该文件仅记录相对 build/ 的路径。",  # 说明文字
+            "不包含任何二进制内容。",  # 重申原则
+        ],
+    }
+    ensure_directory(build_root)  # 确保 build 目录存在
+    index_path = build_root / "index.json"  # 索引文件路径
+    with index_path.open("w", encoding="utf-8") as handle:  # 打开文本文件
+        json.dump(index_payload, handle, ensure_ascii=False, indent=2)  # 写入 JSON
+        handle.write("\n")  # 结尾换行
+    logger.info("[INFO] Wrote index: %s", index_path.as_posix())  # 记录索引写入
+    logger.info("[DONE] Import finished without binary generation.")  # 完成日志
+    print("[DONE] Import finished without binary generation.")  # 控制台提示
+    handler.close()  # 关闭处理器
+    logger.handlers = []  # 清空处理器避免重复
+    return index_data  # 返回索引数据供调用方使用
 
 
 def parse_arguments() -> argparse.Namespace:
-    """Parse CLI arguments."""
+    """解析命令行参数。"""
 
-    parser = argparse.ArgumentParser(description='Mirror user assets into assets/build (text operations only).')
-    parser.add_argument(
-        '--root',
-        type=Path,
-        default=Path(__file__).resolve().parent.parent,
-        help='Repository root directory. Defaults to the project root detected from this script.',
-    )
-    parser.add_argument(
-        '--move',
-        action='store_true',
-        help='Move files instead of copying them. Copying is the default to preserve the source archive.',
-    )
-    return parser.parse_args()
-
-
-def iter_user_files(source_root: Path) -> Iterable[Path]:
-    """Yield all files contained within ``source_root``."""
-
-    for candidate in sorted(source_root.rglob('*')):
-        if candidate.is_file():
-            yield candidate
-
-
-def validate_path(relative: Path) -> None:
-    """Ensure that the provided relative path adheres to the naming policy."""
-
-    if not relative.parts:
-        raise ValueError('Empty asset path encountered during import.')
-    top_level = relative.parts[0]
-    if top_level not in ALLOWED_TOP_LEVEL:
-        raise ValueError(f'Unsupported asset category: {top_level}')
-    if top_level == 'audio' and len(relative.parts) > 1:
-        subcategory = relative.parts[1]
-        if subcategory not in ALLOWED_AUDIO_SUBDIRS:
-            raise ValueError(f'Unsupported audio sub-category: {subcategory}')
-
-
-def mirror_assets(
-    source_root: Path,
-    build_root: Path,
-    move_mode: bool,
-    logger: logging.Logger,
-) -> List[Dict[str, object]]:
-    """Mirror files into ``build_root`` and return manifest entries."""
-
-    manifest: List[Dict[str, object]] = []
-    build_root.mkdir(parents=True, exist_ok=True)
-
-    for file_path in iter_user_files(source_root):
-        relative = file_path.relative_to(source_root)
-        top_level = relative.parts[0] if relative.parts else ''
-        if top_level in ALLOWED_TOP_LEVEL_FILES:
-            logger.info('skipped %s (metadata file)', file_path)
-            continue
-        validate_path(relative)
-
-        destination = build_root / relative
-        destination.parent.mkdir(parents=True, exist_ok=True)
-
-        if move_mode:
-            operation = 'moved'
-            if destination.exists():
-                destination.unlink()
-            shutil.move(str(file_path), destination)
-        else:
-            operation = 'copied'
-            shutil.copy2(file_path, destination)
-
-        stat = destination.stat()
-        manifest.append(
-            {
-                'category': relative.parts[0],
-                'relativePath': str(relative).replace('\\', '/'),
-                'size': stat.st_size,
-                'modified': datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
-                'operation': operation,
-            }
-        )
-        logger.info('%s %s -> %s', operation, file_path, destination)
-
-    return manifest
-
-
-def write_index(build_root: Path, manifest: List[Dict[str, object]]) -> None:
-    """Write the manifest to ``asset_index.json`` within ``build_root``."""
-
-    index_path = build_root / 'asset_index.json'
-    payload = {
-        'generatedAt': datetime.now(timezone.utc).isoformat(),
-        'files': manifest,
-    }
-    index_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding='utf-8')
+    parser = argparse.ArgumentParser(description="导入用户素材到统一目录")  # 创建解析器
+    parser.add_argument("--move", action="store_true", help="是否将文件移动而非复制")  # move 参数
+    parser.add_argument("--rules", type=str, help="自定义规则 JSON 路径", default=None)  # 规则文件参数
+    parser.add_argument("--root", type=str, help="指定仓库根目录，默认为脚本上级", default=None)  # 自定义根目录
+    return parser.parse_args()  # 返回解析结果
 
 
 def main() -> None:
-    """Entry point for the import utility."""
+    """脚本入口函数。"""
 
-    args = parse_arguments()
-    root = args.root.resolve()
-    source_root = root / 'assets/user_imports'
-    build_root = root / 'assets/build'
-    log_path = root / 'logs/user_imports.log'
-
-    logger = configure_logger(log_path)
-
-    if not source_root.exists():
-        logger.error('Source directory does not exist: %s', source_root)
-        raise SystemExit(1)
-
-    logger.info('user-import start | source=%s | build=%s | move=%s', source_root, build_root, args.move)
-
-    # Ensure the build directory is cleared without touching unrelated files.
-    if build_root.exists():
-        for entry in sorted(build_root.iterdir()):
-            if entry.name == '.gitkeep':
-                continue
-            if entry.is_file():
-                entry.unlink()
-            else:
-                shutil.rmtree(entry)
-
-    manifest = mirror_assets(source_root, build_root, args.move, logger)
-    write_index(build_root, manifest)
-
-    logger.info('user-import completed | %d files processed', len(manifest))
-    print('✅ Assets successfully imported (text-only operations)')
+    args = parse_arguments()  # 获取命令行参数
+    root = Path(args.root).resolve() if args.root else Path(__file__).resolve().parents[1]  # 计算根目录
+    rules_path = Path(args.rules).resolve() if args.rules else None  # 解析规则路径
+    try:  # 捕获运行过程中的异常
+        run_import(root, move_mode=args.move, rule_file=rules_path)  # 执行导入
+    except Exception as error:  # 捕获异常
+        print(f"[ERROR] {error}")  # 控制台输出错误
+        raise  # 重新抛出以便上层处理
 
 
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":  # 仅在直接执行时运行
+    main()  # 调用入口函数
+

--- a/scripts/preview_user_assets.py
+++ b/scripts/preview_user_assets.py
@@ -1,120 +1,72 @@
 #!/usr/bin/env python3
-"""Generate a lightweight preview index for user-imported assets.
+# 严禁生成二进制文件，此脚本仅处理 JSON 文本与统计
+"""根据 build/index.json 生成预览清单。"""
 
-The preview index is a pure-text JSON file that summarises the contents of
-``assets/build``.  It enables tooling and front-end code to quickly enumerate
-available assets without touching binary payloads.  The script performs three
-steps:
+from __future__ import annotations  # 启用前向引用以辅助类型提示
 
-1. Walk ``assets/build`` and catalogue each file by its relative path.
-2. Group the results by their first directory component so the UI can display
-   categories such as ``audio`` or ``characters``.
-3. Write the resulting data to ``assets/preview_index.json`` and record the
-   activity in ``logs/user_imports.log``.
-
-Only the Python standard library is used, ensuring compatibility with minimal
-CI images.
-"""
-
-from __future__ import annotations
-
-import argparse
-import json
-import logging
-from pathlib import Path
-from typing import Dict, List
-
-LOG_FORMAT = '[%(asctime)s] %(levelname)s %(message)s'
+import argparse  # 解析命令行参数
+import json  # 读取与写入 JSON 文本
+from pathlib import Path  # 处理文件路径
+from typing import Dict, List  # 类型提示辅助
 
 
-def configure_logger(log_path: Path) -> logging.Logger:
-    """Configure a shared logger for preview generation."""
+def build_preview_entries(index_data: Dict[str, Dict[str, List[str]]]) -> Dict[str, List[Dict[str, str]]]:
+    """将导入索引结构转换为预览清单结构。"""
 
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    logger = logging.getLogger('user-preview')
-    logger.setLevel(logging.INFO)
-    logger.handlers.clear()
+    audio_entries: List[Dict[str, str]] = []  # 初始化音频条目列表
+    for audio_type, paths in index_data.get("audio", {}).items():  # 遍历音频分类
+        for path in paths:  # 遍历每个路径
+            audio_entries.append({"type": audio_type, "path": f"assets/build/{path}"})  # 追加条目
+    image_entries: List[Dict[str, str]] = []  # 初始化图像条目列表
+    for image_type, paths in index_data.get("images", {}).items():  # 遍历图像分类
+        for path in paths:  # 遍历每个路径
+            image_entries.append({"type": image_type, "path": f"assets/build/{path}"})  # 追加条目
+    return {"audio": audio_entries, "images": image_entries}  # 返回组合结果
 
-    formatter = logging.Formatter(LOG_FORMAT)
 
-    file_handler = logging.FileHandler(log_path, encoding='utf-8')
-    file_handler.setFormatter(formatter)
-    logger.addHandler(file_handler)
+def run_preview(root: Path) -> Dict[str, List[Dict[str, str]]]:
+    """执行预览索引生成流程。"""
 
-    stream_handler = logging.StreamHandler()
-    stream_handler.setFormatter(formatter)
-    logger.addHandler(stream_handler)
-
-    return logger
+    assets_root = root / "assets"  # 资产根目录
+    build_root = assets_root / "build"  # build 目录
+    index_path = build_root / "index.json"  # 导入索引文件路径
+    if not index_path.exists():  # 如果索引不存在
+        raise FileNotFoundError("缺少 assets/build/index.json，请先执行导入脚本")  # 抛出异常
+    with index_path.open("r", encoding="utf-8") as handle:  # 打开索引文件
+        index_data = json.load(handle)  # 解析 JSON 内容
+    preview_data = build_preview_entries(index_data)  # 构造预览数据
+    preview_path = assets_root / "preview_index.json"  # 预览文件路径
+    with preview_path.open("w", encoding="utf-8") as handle:  # 打开输出文件
+        json.dump(preview_data, handle, ensure_ascii=False, indent=2)  # 写入 JSON
+        handle.write("\n")  # 末尾换行保持整洁
+    audio_count = len(preview_data["audio"])  # 统计音频条目数量
+    image_count = len(preview_data["images"])  # 统计图像条目数量
+    print(
+        f"[DONE] Preview index written: {preview_path.as_posix()} (audio={audio_count}, images={image_count})"
+    )  # 控制台输出摘要
+    return preview_data  # 返回数据供调用方使用
 
 
 def parse_arguments() -> argparse.Namespace:
-    """Parse CLI arguments."""
+    """解析命令行参数。"""
 
-    parser = argparse.ArgumentParser(description='Create a text-only preview index for imported assets.')
-    parser.add_argument(
-        '--root',
-        type=Path,
-        default=Path(__file__).resolve().parent.parent,
-        help='Repository root directory. Defaults to the project root detected from this script.',
-    )
-    return parser.parse_args()
-
-
-def scan_build_directory(build_root: Path) -> Dict[str, List[Dict[str, object]]]:
-    """Enumerate files inside ``build_root`` grouped by category."""
-
-    if not build_root.exists():
-        raise FileNotFoundError(f'build directory does not exist: {build_root}')
-
-    grouped: Dict[str, List[Dict[str, object]]] = {}
-
-    for path in sorted(build_root.rglob('*')):
-        if not path.is_file():
-            continue
-        relative = path.relative_to(build_root)
-        category = relative.parts[0] if relative.parts else 'root'
-        grouped.setdefault(category, []).append(
-            {
-                'path': str(relative).replace('\\', '/'),
-                'size': path.stat().st_size,
-                'type': path.suffix.lstrip('.').lower() or 'unknown',
-            }
-        )
-
-    for entries in grouped.values():
-        entries.sort(key=lambda item: item['path'])
-
-    return grouped
-
-
-def write_preview(root: Path, index: Dict[str, List[Dict[str, object]]]) -> Path:
-    """Write the preview index next to the shared assets directory."""
-
-    target = root / 'assets/preview_index.json'
-    target.write_text(json.dumps(index, ensure_ascii=False, indent=2), encoding='utf-8')
-    return target
+    parser = argparse.ArgumentParser(description="生成用户素材预览清单")  # 创建解析器
+    parser.add_argument("--root", type=str, help="指定仓库根目录，默认为脚本上级", default=None)  # 自定义根目录
+    return parser.parse_args()  # 返回参数结果
 
 
 def main() -> None:
-    """Entry point for preview generation."""
+    """脚本入口。"""
 
-    args = parse_arguments()
-    root = args.root.resolve()
-    build_root = root / 'assets/build'
-    log_path = root / 'logs/user_imports.log'
-
-    logger = configure_logger(log_path)
-    logger.info('user-preview start | build=%s', build_root)
-
-    index = scan_build_directory(build_root)
-    target = write_preview(root, index)
-
-    total_files = sum(len(items) for items in index.values())
-    logger.info('user-preview completed | %d files indexed | output=%s', total_files, target)
-
-    print('✅ Assets preview index refreshed')
+    args = parse_arguments()  # 获取参数
+    root = Path(args.root).resolve() if args.root else Path(__file__).resolve().parents[1]  # 计算根目录
+    try:  # 捕获异常
+        run_preview(root)  # 执行预览生成
+    except Exception as error:  # 捕获错误
+        print(f"[ERROR] {error}")  # 输出错误信息
+        raise  # 将异常重新抛出方便调试
 
 
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":  # 直接执行时运行
+    main()  # 调用主函数
+

--- a/tests/test_import_and_preview.py
+++ b/tests/test_import_and_preview.py
@@ -1,0 +1,78 @@
+"""针对用户素材导入与预览索引的文本级测试。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.import_user_assets import run_import
+from scripts.preview_user_assets import run_preview
+
+
+def _write_dummy_file(path: Path, content: str) -> None:
+    """在给定路径写入文本内容，用于模拟素材文件。"""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_import_generates_index(tmp_path: Path) -> None:
+    """验证导入与预览脚本在纯文本模式下正确工作。"""
+
+    root = tmp_path
+    # 准备示例素材（使用文本文件模拟 ogg/png，符合“只写文本”的约束）
+    _write_dummy_file(root / "assets/user_imports/Audio/BGM/field.ogg", "BGM")
+    _write_dummy_file(root / "assets/user_imports/Audio/SE/click.ogg", "SE")
+    _write_dummy_file(root / "assets/user_imports/Graphics/Characters/Hero.png", "IMG")
+    _write_dummy_file(root / "assets/user_imports/Graphics/Battlebacks1/Forest.png", "BG")
+
+    # 执行导入脚本（复制模式）
+    run_import(root, move_mode=False, rule_file=None)
+
+    build_root = root / "assets/build"
+    index_path = build_root / "index.json"
+    assert index_path.exists(), "导入后必须生成 assets/build/index.json"
+
+    # 校验索引内容与实际文件对齐
+    with index_path.open("r", encoding="utf-8") as handle:
+        index_payload = json.load(handle)
+
+    for _category, entries in index_payload["audio"].items():
+        for relative in entries:
+            assert (build_root / relative).exists(), f"音频路径缺失: {relative}"
+
+    for _category, entries in index_payload["images"].items():
+        for relative in entries:
+            assert (build_root / relative).exists(), f"图像路径缺失: {relative}"
+
+    # 确保没有生成额外的二进制文件：build 与 user 的文件集合应仅以复制关系存在
+    user_files = {
+        path.relative_to(root).as_posix()
+        for path in (root / "assets/user_imports").rglob("*")
+        if path.is_file()
+    }
+    build_files = {
+        path.relative_to(root).as_posix()
+        for path in build_root.rglob("*")
+        if path.is_file()
+    }
+    for build_file in build_files:
+        original_name = Path(build_file).name
+        suffix = Path(build_file).suffix.lower()
+        if suffix in {".json"}:  # 索引文件不参与校验
+            continue
+        assert any(Path(entry).name == original_name for entry in user_files), "复制的文件必须来源于用户素材"
+
+    # 执行预览脚本并检查结构
+    preview_data = run_preview(root)
+    preview_path = root / "assets/preview_index.json"
+    assert preview_path.exists(), "预览清单需要写入 assets/preview_index.json"
+    assert all("type" in item and "path" in item for item in preview_data["audio"]), "音频清单缺少字段"
+    assert all("type" in item and "path" in item for item in preview_data["images"]), "图像清单缺少字段"
+
+    print("✅ MiniWorld import/preview text-only pipeline passed")


### PR DESCRIPTION
## Summary
- add a text-only import script that maps `assets/user_imports` into the normalized `assets/build` layout and refreshes the index
- add a preview manifest generator and teach the MiniWorld loader to queue assets from `assets/preview_index.json`
- document the asset pipeline, extend Makefile helpers, and add pytest coverage for the import/preview workflow

## Testing
- make user-import
- make user-preview
- pytest tests/test_import_and_preview.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e9e81e2db88328ba59adf3ea4408b8