### PR TITLE
Add resource browser scene for MiniWorld assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: miniworld-dev miniworld-build miniworld-test user-import user-import-move user-import-rules user-preview build-all
+.PHONY: miniworld-dev miniworld-build miniworld-test user-import user-import-move user-import-rules user-preview build-all miniworld-preview
 
 miniworld-dev:
 	pnpm --filter miniworld dev
@@ -8,6 +8,9 @@ miniworld-build:
 
 miniworld-test:
 	pnpm --filter miniworld test
+
+miniworld-preview:
+	pnpm --filter miniworld dev -- --scene=ResourceBrowser
 
 user-import:
 	python3 scripts/import_user_assets.py

--- a/frontend/miniworld/src/config/keys.ts
+++ b/frontend/miniworld/src/config/keys.ts
@@ -16,3 +16,4 @@ export const KEY_JOURNAL = 'J'; // 任务日志键
 export const KEY_BUILD_MODE = 'U'; // 建造模式切换键
 export const KEY_BUILD_APPROVE = 'Y'; // 建造审批通过键
 export const KEY_BUILD_REJECT = 'N'; // 建造审批拒绝键
+export const KEY_RESOURCE_BROWSER = 'R'; // 资源浏览器键

--- a/frontend/miniworld/src/game.ts
+++ b/frontend/miniworld/src/game.ts
@@ -4,6 +4,7 @@ import WorldScene from './scenes/WorldScene'; // 引入世界场景
 import UIScene from './scenes/UIScene'; // 引入UI场景
 import GlossaryScene from './ui/glossary/GlossaryScene'; // 引入图鉴场景
 import AchievementScene from './ui/achievements/AchievementScene'; // 引入成就场景
+import ResourceBrowserScene from './ui/ResourceBrowserScene'; // 引入资源浏览器场景
 import { PIXEL_CONFIG } from './config/pixel'; // 引入像素渲染配置
 // 分隔注释 // 保持行有注释
 export function createMiniWorldGame(): Phaser.Game { // 导出创建游戏实例的函数
@@ -13,9 +14,15 @@ export function createMiniWorldGame(): Phaser.Game { // 导出创建游戏实例
     height: 320, // 设置游戏高度
     parent: 'app', // 挂载到页面上的节点
     backgroundColor: '#1d1f21', // 设置背景颜色
-    scene: [BootScene, WorldScene, UIScene, GlossaryScene, AchievementScene], // 注册场景顺序
+    scene: [BootScene, WorldScene, UIScene, GlossaryScene, AchievementScene, ResourceBrowserScene], // 注册场景顺序
     scale: { mode: Phaser.Scale.FIT, autoCenter: Phaser.Scale.CENTER_BOTH, zoom: 2 }, // 缩放与居中设置
-    render: { pixelArt: true, antialias: PIXEL_CONFIG.antialias, roundPixels: PIXEL_CONFIG.roundPixels, mipmapFilter: PIXEL_CONFIG.mipmap ? Phaser.Textures.FilterMode.LINEAR : Phaser.Textures.FilterMode.NEAREST }, // 像素渲染配置
+    dom: { createContainer: true }, // 启用DOM容器以嵌入音频控件
+    render: {
+      pixelArt: true,
+      antialias: PIXEL_CONFIG.antialias,
+      roundPixels: PIXEL_CONFIG.roundPixels,
+      mipmapFilter: PIXEL_CONFIG.mipmap ? Phaser.Textures.FilterMode.LINEAR : Phaser.Textures.FilterMode.NEAREST,
+    }, // 像素渲染配置
   }; // 结束配置对象
   return new Phaser.Game(config); // 创建并返回游戏实例
 } // 函数结束

--- a/frontend/miniworld/src/main.ts
+++ b/frontend/miniworld/src/main.ts
@@ -1,3 +1,17 @@
 import { createMiniWorldGame } from './game'; // 引入创建游戏的方法
-// 分隔注释 // 保持行有注释
+
+declare global {
+  interface Window {
+    __MINIWORLD_START_SCENE__?: string; // 通过URL参数指定的启动场景
+  }
+}
+
+// 解析URL参数，允许通过 ?scene=ResourceBrowser 等形式直接打开特定界面
+const params = new URLSearchParams(window.location.search);
+const requestedScene = params.get('scene');
+if (requestedScene) {
+  window.__MINIWORLD_START_SCENE__ = requestedScene;
+}
+
 createMiniWorldGame(); // 立即创建游戏实例
+

--- a/frontend/miniworld/src/scenes/BootScene.ts
+++ b/frontend/miniworld/src/scenes/BootScene.ts
@@ -18,6 +18,12 @@ export default class BootScene extends Phaser.Scene { // 定义启动场景
     if (this.loadingLabel) { // 如果存在文本
       this.loadingLabel.setText('加载完成'); // 更新文案
     } // 条件结束
-    this.scene.start('WorldScene'); // 切换到世界场景
+    const requested = (window as typeof window & { __MINIWORLD_START_SCENE__?: string }).__MINIWORLD_START_SCENE__;
+    const normalized = requested?.toLowerCase() ?? '';
+    let target: string = 'WorldScene';
+    if (normalized === 'resourcebrowser' || normalized === 'resourcebrowserscene') {
+      target = 'ResourceBrowserScene';
+    }
+    this.scene.start(target); // 根据参数切换到目标场景
   } // 方法结束
 } // 类结束

--- a/frontend/miniworld/src/scenes/WorldScene.ts
+++ b/frontend/miniworld/src/scenes/WorldScene.ts
@@ -1,5 +1,5 @@
 import Phaser from 'phaser'; // 引入Phaser框架
-import { KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT, KEY_INTERACT, KEY_SAVE, KEY_LOAD, KEY_GLOSSARY, KEY_ACHIEVEMENT, KEY_SHOP, KEY_SPEED_TOGGLE, KEY_JOURNAL, KEY_BUILD_MODE, KEY_BUILD_APPROVE, KEY_BUILD_REJECT } from '../config/keys'; // 引入按键常量
+import { KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT, KEY_INTERACT, KEY_SAVE, KEY_LOAD, KEY_GLOSSARY, KEY_ACHIEVEMENT, KEY_SHOP, KEY_SPEED_TOGGLE, KEY_JOURNAL, KEY_BUILD_MODE, KEY_BUILD_APPROVE, KEY_BUILD_REJECT, KEY_RESOURCE_BROWSER } from '../config/keys'; // 引入按键常量
 import { genDemoMap, isWalkable, layerOf } from '../world/TileRules'; // 引入地图工具
 import { TileCell, GridPos } from '../world/Types'; // 引入类型定义
 import { getNodeAt, removeNodeAt } from '../world/Nodes'; // 引入资源节点接口
@@ -60,6 +60,7 @@ export default class WorldScene extends Phaser.Scene { // 定义世界场景
   private timeScaleBoost!: TimeScaleBoost; // 快进控制
   private shopKey!: Phaser.Input.Keyboard.Key; // 商店交互键
   private speedKey!: Phaser.Input.Keyboard.Key; // 快进切换键
+  private resourceBrowserKey!: Phaser.Input.Keyboard.Key; // 资源浏览器快捷键
   private hudScene?: UIScene; // UI场景引用
   private pendingTimeState?: ReturnType<TimeSystem['serialize']>; // 待恢复时间数据
   private pendingShopState?: ReturnType<ShopStore['toJSON']>; // 待恢复商店数据
@@ -374,6 +375,10 @@ export default class WorldScene extends Phaser.Scene { // 定义世界场景
     this.journalKey.on('down', () => { // 监听日志键按下
       this.toggleQuestJournal(); // 切换任务日志界面
     }); // 监听结束
+    this.resourceBrowserKey = this.input.keyboard.addKey(KEY_RESOURCE_BROWSER); // 创建资源浏览器键
+    this.resourceBrowserKey.on('down', () => { // 监听资源浏览器键按下
+      this.openResourceBrowser(); // 打开资源浏览器
+    }); // 监听结束
     this.buildToggleKey = this.input.keyboard.addKey(KEY_BUILD_MODE); // 创建建造模式键
     this.buildToggleKey.on('down', () => { // 监听建造模式键按下
       this.toggleBuildMode(); // 切换建造模式
@@ -409,7 +414,7 @@ export default class WorldScene extends Phaser.Scene { // 定义世界场景
     const source = this.registry.get('assetSource') as string | undefined; // 读取素材来源
     this.hudSourceText = this.add.text(8, 8, `素材来源：${source ?? '占位纹理'}`, { fontFamily: 'sans-serif', fontSize: '12px', color: '#ffffff', backgroundColor: 'rgba(0,0,0,0.66)', padding: { x: 4, y: 2 } }); // 创建左上角文本
     this.hudSourceText.setDepth(1200); // 设置渲染深度
-    this.hudControlsText = this.add.text(312, 312, 'Z 采集 / U 建造 / Ctrl+Z 撤销 / Ctrl+Y 重做 / Y 审批 / N 拒绝 / E 商店 / J 日志 / Shift 倍速 / A 自动 / S 保存或跳过 / L 读取 / G 图鉴 / H 成就', { fontFamily: 'sans-serif', fontSize: '12px', color: '#ffffff', backgroundColor: 'rgba(0,0,0,0.66)', padding: { x: 4, y: 2 }, align: 'right' }); // 创建右下角提示
+    this.hudControlsText = this.add.text(312, 312, 'Z 采集 / U 建造 / Ctrl+Z 撤销 / Ctrl+Y 重做 / Y 审批 / N 拒绝 / E 商店 / J 日志 / Shift 倍速 / A 自动 / S 保存或跳过 / L 读取 / G 图鉴 / H 成就 / R 资源浏览器', { fontFamily: 'sans-serif', fontSize: '12px', color: '#ffffff', backgroundColor: 'rgba(0,0,0,0.66)', padding: { x: 4, y: 2 }, align: 'right' }); // 创建右下角提示
     this.hudControlsText.setOrigin(1, 1); // 设置锚点
     this.hudControlsText.setDepth(1200); // 设置深度
   } // 方法结束
@@ -1164,6 +1169,11 @@ export default class WorldScene extends Phaser.Scene { // 定义世界场景
   private openGlossaryScene(): void { // 打开图鉴场景
     this.scene.pause(); // 暂停世界
     this.scene.launch('GlossaryScene'); // 启动图鉴
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private openResourceBrowser(): void { // 打开资源浏览器
+    this.scene.pause(); // 暂停世界
+    this.scene.launch('ResourceBrowserScene'); // 启动资源浏览器
   } // 方法结束
   // 分隔注释 // 保持行有注释
   private openAchievementScene(): void { // 打开成就场景

--- a/frontend/miniworld/src/ui/ResourceBrowserScene.ts
+++ b/frontend/miniworld/src/ui/ResourceBrowserScene.ts
@@ -1,0 +1,207 @@
+import Phaser from 'phaser'; // 引入Phaser以构建场景
+import { ResourceListPanel, type ResourceListPanelAPI, type ResourceListPanelConfig } from './ResourceListPanel'; // 引入左侧列表面板
+import {
+  ResourcePreviewPanel,
+  type ResourcePreviewPanelAPI,
+  type ResourcePreviewPanelConfig,
+  type ResourceIndex,
+  type ResourceCategory,
+  type ResourcePreviewItem,
+} from './ResourcePreviewPanel'; // 引入右侧预览面板与共享类型
+
+/**
+ * 资源浏览器场景：读取 preview_index.json 后，将音频与图片资源以纯阅读模式展示。
+ * 场景仅根据文件路径创建预览，不生成或导出任何二进制数据。
+ */
+export default class ResourceBrowserScene extends Phaser.Scene {
+  private listPanel!: ResourceListPanelAPI; // 左侧列表面板
+  private previewPanel!: ResourcePreviewPanelAPI; // 右侧预览面板
+  private resources: ResourceIndex = { images: [], audio: [] }; // 缓存JSON数据
+  private currentCategory: ResourceCategory = 'images'; // 当前激活的类别
+  private escKey?: Phaser.Input.Keyboard.Key; // ESC关闭快捷键
+
+  public constructor() {
+    super('ResourceBrowserScene'); // 注册场景键名
+  }
+
+  /**
+   * Phaser 创建阶段：初始化界面、注册事件并开始异步加载 JSON。
+   */
+  public create(): void {
+    console.info('✅ ResourceBrowserScene initialized'); // 按验收标准输出日志
+    this.buildStaticUI(); // 渲染背景与说明文本
+    this.listPanel = this.createListPanel(this.createListPanelConfig()); // 创建列表面板
+    this.previewPanel = this.createPreviewPanel(this.createPreviewPanelConfig()); // 创建预览面板
+    this.registerShutdownHooks(); // 绑定销毁钩子
+    this.setupCloseShortcut(); // 绑定ESC退出
+    void this.reloadResources(); // 异步加载JSON索引
+  }
+
+  /**
+   * 将 preview_index.json 重新加载一遍，可供测试调用。
+   */
+  public async reloadResources(): Promise<void> {
+    try {
+      const response = await fetch('assets/preview_index.json'); // 读取JSON
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = (await response.json()) as ResourceIndex; // 解析JSON
+      this.handleDataLoaded(data); // 更新面板
+      console.info(`✅ preview_index.json loaded (${this.resources.images.length} images, ${this.resources.audio.length} audio)`);
+      console.info('✅ Text-only operations, no binary generated');
+    } catch (error) {
+      console.error('ResourceBrowserScene failed to load preview_index.json', error);
+    }
+  }
+
+  /**
+   * 提供给测试的便捷访问方法，返回当前资源数量。
+   */
+  public getLoadedCounts(): { images: number; audio: number } {
+    return { images: this.resources.images.length, audio: this.resources.audio.length };
+  }
+
+  /**
+   * 返回当前标签文本，便于测试验证。
+   */
+  public getTabLabels(): string[] {
+    return this.listPanel?.getTabLabels() ?? [];
+  }
+
+  /**
+   * 返回当前预览类型。
+   */
+  public getCurrentPreviewType(): 'image' | 'audio' | null {
+    return this.previewPanel?.getCurrentPreviewType() ?? null;
+  }
+
+  /**
+   * 将加载好的数据写入状态并刷新界面。
+   */
+  protected handleDataLoaded(data: ResourceIndex): void {
+    this.resources = {
+      images: data.images ?? [],
+      audio: data.audio ?? [],
+    };
+    this.listPanel.setResources(this.resources);
+    this.listPanel.setActiveCategory(this.currentCategory);
+  }
+
+  /**
+   * 创建背景、说明文字等静态元素。
+   */
+  protected buildStaticUI(): void {
+    this.cameras.main.setBackgroundColor('rgba(0,0,0,0.75)'); // 半透明背景
+    const overlay = this.add.rectangle(0, 0, this.scale.width, this.scale.height, 0x000000, 0.7);
+    overlay.setOrigin(0, 0);
+
+    const title = this.add.text(16, 12, '资源浏览器', {
+      fontFamily: 'sans-serif',
+      fontSize: '18px',
+      color: '#ffffff',
+    });
+    const hint = this.add.text(16, 36, '左侧选择资源，右侧预览；按 ESC 返回世界。', {
+      fontFamily: 'sans-serif',
+      fontSize: '12px',
+      color: '#cccccc',
+    });
+    hint.setWordWrapWidth(this.scale.width - 32);
+    hint.setLineSpacing(4);
+  }
+
+  /**
+   * 构造列表面板配置，集中管理布局参数。
+   */
+  private createListPanelConfig(): ResourceListPanelConfig {
+    return {
+      scene: this,
+      bounds: { x: 16, y: 64, width: 140, height: this.scale.height - 80 },
+      initialCategory: this.currentCategory,
+      onCategoryChange: (category) => this.handleCategoryChange(category),
+      onItemSelected: (category, item) => this.handleItemSelected(category, item),
+    };
+  }
+
+  /**
+   * 构造预览面板配置。
+   */
+  private createPreviewPanelConfig(): ResourcePreviewPanelConfig {
+    const leftWidth = 140 + 16 * 2;
+    return {
+      scene: this,
+      bounds: { x: leftWidth, y: 64, width: this.scale.width - leftWidth - 16, height: this.scale.height - 80 },
+    };
+  }
+
+  /**
+   * 创建列表面板，可被测试类覆盖以替换实现。
+   */
+  protected createListPanel(config: ResourceListPanelConfig): ResourceListPanelAPI {
+    return new ResourceListPanel(config);
+  }
+
+  /**
+   * 创建预览面板，可被测试类覆盖以替换实现。
+   */
+  protected createPreviewPanel(config: ResourcePreviewPanelConfig): ResourcePreviewPanelAPI {
+    return new ResourcePreviewPanel(config);
+  }
+
+  /**
+   * 标签切换时的回调：记录当前类别并清空预览。
+   */
+  private handleCategoryChange(category: ResourceCategory): void {
+    this.currentCategory = category;
+    this.previewPanel.clearPreview();
+  }
+
+  /**
+   * 用户选择资源时的回调：触发预览展示。
+   */
+  private handleItemSelected(category: ResourceCategory, item: ResourcePreviewItem): void {
+    this.currentCategory = category;
+    this.previewPanel.showResource(category, item);
+  }
+
+  /**
+   * 绑定 ESC 按键用于关闭场景。
+   */
+  private setupCloseShortcut(): void {
+    const keyboard = this.input.keyboard;
+    if (!keyboard) {
+      return;
+    }
+    this.escKey = keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
+    this.escKey.on('down', () => {
+      this.exitScene();
+    });
+  }
+
+  /**
+   * 注册场景销毁钩子，清理子组件与键位。
+   */
+  private registerShutdownHooks(): void {
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      this.listPanel?.destroy();
+      this.previewPanel?.destroy();
+      if (this.escKey) {
+        this.input.keyboard?.removeKey(this.escKey);
+        this.escKey = undefined;
+      }
+    });
+  }
+
+  /**
+   * 退出场景并恢复或启动世界场景。
+   */
+  private exitScene(): void {
+    this.scene.stop();
+    if (this.scene.isPaused('WorldScene')) {
+      this.scene.resume('WorldScene');
+    } else if (!this.scene.isActive('WorldScene')) {
+      this.scene.start('WorldScene');
+    }
+  }
+}
+

--- a/frontend/miniworld/src/ui/ResourceListPanel.ts
+++ b/frontend/miniworld/src/ui/ResourceListPanel.ts
@@ -1,0 +1,205 @@
+import Phaser from 'phaser'; // 引入Phaser框架供类型与运行时使用
+import type { ResourceCategory, ResourceIndex, ResourcePreviewItem } from './ResourcePreviewPanel'; // 引入共享类型，保持数据结构一致
+
+/**
+ * 定义左侧列表面板创建所需的配置。包含基本布局信息以及事件回调。
+ * scene       -> 当前所属的场景实例，便于创建文本与容器。
+ * bounds      -> 面板的矩形区域，使用像素坐标描述。
+ * initialCategory -> 初始选中的类别（images 或 audio）。
+ * onCategoryChange -> 当用户切换标签页时触发。
+ * onItemSelected   -> 当用户点击具体资源文件时触发。
+ */
+export interface ResourceListPanelConfig {
+  scene: Phaser.Scene;
+  bounds: { x: number; y: number; width: number; height: number };
+  initialCategory: ResourceCategory;
+  onCategoryChange: (category: ResourceCategory) => void;
+  onItemSelected: (category: ResourceCategory, item: ResourcePreviewItem) => void;
+}
+
+/**
+ * 定义面板对外暴露的最小接口，方便测试替换或模拟。
+ */
+export interface ResourceListPanelAPI {
+  setResources(index: ResourceIndex): void; // 传入解析好的索引数据
+  setActiveCategory(category: ResourceCategory): void; // 切换当前标签
+  clearSelection(): void; // 清空当前选择
+  getTabLabels(): string[]; // 返回当前标签文本，用于测试验证
+  destroy(): void; // 销毁内部生成的Phaser对象
+}
+
+/**
+ * 列表面板负责展示两类资源（图片 / 音频）的文件名，
+ * 并在用户选择时通过回调通知场景。所有显示元素使用Phaser文本与容器生成，
+ * 不缓存或修改二进制文件，仅依赖 JSON 数据中的路径。
+ */
+export class ResourceListPanel implements ResourceListPanelAPI {
+  private readonly scene: Phaser.Scene; // 保存场景引用方便创建元素
+  private readonly bounds: { x: number; y: number; width: number; height: number }; // 面板区域
+  private readonly onCategoryChange: (category: ResourceCategory) => void; // 标签切换回调
+  private readonly onItemSelected: (category: ResourceCategory, item: ResourcePreviewItem) => void; // 项目选择回调
+  private readonly root: Phaser.GameObjects.Container; // 根容器用于整体控制
+  private readonly tabTexts: { category: ResourceCategory; label: Phaser.GameObjects.Text }[] = []; // 标签文本集合
+  private entryTexts: Phaser.GameObjects.Text[] = []; // 文件名文本集合
+  private resources: ResourceIndex = { images: [], audio: [] }; // 当前资源索引
+  private activeCategory: ResourceCategory; // 当前激活的类别
+  private selectedPath: string | null = null; // 当前选中的资源路径
+
+  public constructor(config: ResourceListPanelConfig) {
+    this.scene = config.scene;
+    this.bounds = config.bounds;
+    this.onCategoryChange = config.onCategoryChange;
+    this.onItemSelected = config.onItemSelected;
+    this.activeCategory = config.initialCategory;
+
+    // 创建根容器并配置基础外观
+    this.root = this.scene.add.container(this.bounds.x, this.bounds.y); // 创建容器
+    const bg = this.scene.add.rectangle(0, 0, this.bounds.width, this.bounds.height, 0x000000, 0.55); // 背景矩形
+    bg.setOrigin(0, 0); // 左上角为原点
+    bg.setStrokeStyle(1, 0xffffff, 0.2); // 轻微描边便于区分
+    this.root.add(bg); // 背景加入容器
+
+    // 面板标题
+    const title = this.scene.add.text(8, 8, '资源类别', {
+      fontFamily: 'sans-serif',
+      fontSize: '14px',
+      color: '#ffeeaa',
+    }); // 添加标题
+    this.root.add(title);
+
+    this.createTabs(); // 初始化标签
+  }
+
+  /**
+   * 根据当前数据创建 Images 与 Audio 两个标签，并绑定点击事件。
+   */
+  private createTabs(): void {
+    const tabNames: { category: ResourceCategory; label: string }[] = [
+      { category: 'images', label: 'Images' },
+      { category: 'audio', label: 'Audio' },
+    ];
+    const startX = 8; // 标签起始X
+    const startY = 32; // 标签起始Y
+    const gap = 70; // 标签间隔
+
+    tabNames.forEach((tab, index) => {
+      const text = this.scene.add.text(startX + index * gap, startY, tab.label, {
+        fontFamily: 'sans-serif',
+        fontSize: '13px',
+        color: '#cccccc',
+      }); // 创建标签文本
+      text.setInteractive({ useHandCursor: true }); // 开启交互
+      text.on('pointerdown', () => {
+        if (this.activeCategory !== tab.category) {
+          this.setActiveCategory(tab.category); // 切换类别
+        }
+      }); // 点击事件
+      this.root.add(text); // 添加到容器
+      this.tabTexts.push({ category: tab.category, label: text }); // 保存引用
+    });
+    this.updateTabStyles(); // 初始化高亮样式
+  }
+
+  /**
+   * 更新标签高亮状态，确保当前类别以亮色显示。
+   */
+  private updateTabStyles(): void {
+    this.tabTexts.forEach((entry) => {
+      if (entry.category === this.activeCategory) {
+        entry.label.setStyle({ color: '#ffffff', backgroundColor: 'rgba(255,255,255,0.15)' });
+      } else {
+        entry.label.setStyle({ color: '#cccccc', backgroundColor: undefined });
+      }
+    });
+  }
+
+  /**
+   * 将解析后的资源索引传入面板，随后刷新列表。
+   */
+  public setResources(index: ResourceIndex): void {
+    this.resources = index;
+    this.renderList(); // 刷新当前列表
+  }
+
+  /**
+   * 刷新当前类别对应的文件名列表。
+   */
+  private renderList(): void {
+    this.entryTexts.forEach((text) => text.destroy()); // 清理旧文本
+    this.entryTexts = []; // 重置列表
+
+    const list = this.resources[this.activeCategory] ?? []; // 读取当前类别数组
+    const startX = 8;
+    const startY = 64;
+    const lineHeight = 20;
+
+    list.forEach((item, index) => {
+      const fileName = item.path.split('/').pop() ?? item.path; // 提取文件名
+      const label = this.scene.add.text(startX, startY + index * lineHeight, fileName, {
+        fontFamily: 'monospace',
+        fontSize: '12px',
+        color: '#aaddff',
+      }); // 创建文件名文本
+      label.setInteractive({ useHandCursor: true }); // 开启点击
+      label.on('pointerdown', () => {
+        this.selectedPath = item.path; // 记录当前选择
+        this.updateEntryStyles(); // 更新高亮
+        this.onItemSelected(this.activeCategory, item); // 通知上层
+      });
+      label.setData('path', item.path); // 保存路径便于后续高亮
+      this.root.add(label); // 加入容器
+      this.entryTexts.push(label); // 保存引用
+    });
+    this.updateEntryStyles(); // 初次渲染时同步样式
+  }
+
+  /**
+   * 更新文件名列表的高亮状态。
+   */
+  private updateEntryStyles(): void {
+    this.entryTexts.forEach((label) => {
+      const path = label.getData('path') as string | undefined;
+      if (path && path === this.selectedPath) {
+        label.setStyle({ color: '#ffffff', backgroundColor: 'rgba(255,255,255,0.15)' });
+      } else {
+        label.setStyle({ color: '#aaddff', backgroundColor: undefined });
+      }
+    });
+  }
+
+  /**
+   * 切换标签时调用，触发回调并刷新列表。
+   */
+  public setActiveCategory(category: ResourceCategory): void {
+    this.activeCategory = category;
+    this.selectedPath = null; // 清空选中状态
+    this.updateTabStyles(); // 更新标签高亮
+    this.renderList(); // 刷新列表内容
+    this.onCategoryChange(category); // 通知场景
+  }
+
+  /**
+   * 清空选中状态并刷新高亮。
+   */
+  public clearSelection(): void {
+    this.selectedPath = null;
+    this.updateEntryStyles();
+  }
+
+  /**
+   * 返回标签文本内容，主要用于单元测试校验标签生成是否正确。
+   */
+  public getTabLabels(): string[] {
+    return this.tabTexts.map((entry) => entry.label.text);
+  }
+
+  /**
+   * 销毁面板内部生成的所有对象，避免内存泄露。
+   */
+  public destroy(): void {
+    this.entryTexts.forEach((text) => text.destroy());
+    this.tabTexts.forEach((entry) => entry.label.destroy());
+    this.root.destroy();
+  }
+}
+

--- a/frontend/miniworld/src/ui/ResourcePreviewPanel.ts
+++ b/frontend/miniworld/src/ui/ResourcePreviewPanel.ts
@@ -1,0 +1,279 @@
+import Phaser from 'phaser'; // 引入Phaser以创建预览所需的图像与DOM元素
+import './styles/resource_browser.css'; // 引入专用样式，确保音频控件样式统一
+
+/**
+ * 资源类别区分：图片与音频。统一使用字符串字面量便于类型推断。
+ */
+export type ResourceCategory = 'images' | 'audio';
+
+/**
+ * JSON 中每个条目的最小结构，仅包含类型标签与资源路径。
+ */
+export interface ResourcePreviewItem {
+  type: string;
+  path: string;
+}
+
+/**
+ * assets/preview_index.json 的整体结构定义。仅保留 audio 与 images 两个键。
+ */
+export interface ResourceIndex {
+  images: ResourcePreviewItem[];
+  audio: ResourcePreviewItem[];
+}
+
+/**
+ * 预览面板构造所需配置：包含场景引用与面板布局矩形。
+ */
+export interface ResourcePreviewPanelConfig {
+  scene: Phaser.Scene;
+  bounds: { x: number; y: number; width: number; height: number };
+}
+
+/**
+ * 对外暴露的接口，供场景或测试替换。
+ */
+export interface ResourcePreviewPanelAPI {
+  showResource(category: ResourceCategory, item: ResourcePreviewItem): void; // 展示指定资源
+  clearPreview(): void; // 清空预览
+  getCurrentPreviewType(): 'image' | 'audio' | null; // 返回当前预览类型
+  destroy(): void; // 销毁内部对象
+}
+
+/**
+ * 右侧预览面板：图片通过 Phaser 图像对象展示，音频则使用 DOM 音频控件。
+ * 不进行任何二进制导出，仅根据路径引用资源。
+ */
+export class ResourcePreviewPanel implements ResourcePreviewPanelAPI {
+  private readonly scene: Phaser.Scene; // 保存场景引用
+  private readonly bounds: { x: number; y: number; width: number; height: number }; // 区域定义
+  private readonly root: Phaser.GameObjects.Container; // 根容器
+  private readonly background: Phaser.GameObjects.Rectangle; // 背景矩形
+  private readonly pathText: Phaser.GameObjects.Text; // 显示路径的文本
+  private readonly typeText: Phaser.GameObjects.Text; // 显示类型标签
+  private currentImage?: Phaser.GameObjects.Image; // 当前展示的图片
+  private audioDom?: Phaser.GameObjects.DOMElement; // 使用DOMElement承载音频控件
+  private audioElement?: HTMLAudioElement; // 真正的音频元素
+  private readonly textureKeyMap: Map<string, string> = new Map(); // 记录路径与纹理键映射
+  private currentPreviewType: 'image' | 'audio' | null = null; // 当前展示类型
+  private currentPath: string | null = null; // 当前展示资源路径
+
+  public constructor(config: ResourcePreviewPanelConfig) {
+    this.scene = config.scene;
+    this.bounds = config.bounds;
+
+    this.root = this.scene.add.container(this.bounds.x, this.bounds.y); // 创建容器
+    this.background = this.scene.add.rectangle(0, 0, this.bounds.width, this.bounds.height, 0x000000, 0.55);
+    this.background.setOrigin(0, 0);
+    this.background.setStrokeStyle(1, 0xffffff, 0.2);
+    this.root.add(this.background);
+
+    this.pathText = this.scene.add.text(8, 8, '选择资源以查看预览', {
+      fontFamily: 'sans-serif',
+      fontSize: '13px',
+      color: '#ffffff',
+      wordWrap: { width: this.bounds.width - 16 },
+    });
+    this.root.add(this.pathText);
+
+    this.typeText = this.scene.add.text(8, 40, '', {
+      fontFamily: 'sans-serif',
+      fontSize: '12px',
+      color: '#ffeeaa',
+    });
+    this.root.add(this.typeText);
+  }
+
+  /**
+   * 将指定资源显示在预览区域，根据类别选择对应的处理方式。
+   */
+  public showResource(category: ResourceCategory, item: ResourcePreviewItem): void {
+    if (category === 'images') {
+      this.showImage(item);
+    } else {
+      this.showAudio(item);
+    }
+  }
+
+  /**
+   * 清空预览内容：销毁图片并暂停音频。
+   */
+  public clearPreview(): void {
+    this.clearImage();
+    this.hideAudio();
+    this.pathText.setText('选择资源以查看预览');
+    this.typeText.setText('');
+    this.currentPreviewType = null;
+    this.currentPath = null;
+  }
+
+  /**
+   * 返回当前预览类型，主要用于单元测试。
+   */
+  public getCurrentPreviewType(): 'image' | 'audio' | null {
+    return this.currentPreviewType;
+  }
+
+  /**
+   * 销毁所有创建的对象与 DOM 元素。
+   */
+  public destroy(): void {
+    this.clearImage();
+    this.hideAudio(true);
+    this.pathText.destroy();
+    this.typeText.destroy();
+    this.background.destroy();
+    this.root.destroy();
+  }
+
+  /**
+   * 图片预览：按需加载并缩放到面板内。
+   */
+  private showImage(item: ResourcePreviewItem): void {
+    this.hideAudio(); // 切换到图片时暂停音频
+    const key = this.getTextureKey(item.path);
+    if (this.scene.textures.exists(key)) {
+      this.displayImage(key, item);
+      return;
+    }
+
+    if (this.scene.load.isLoading()) {
+      this.scene.load.once(Phaser.Loader.Events.COMPLETE, () => {
+        if (this.scene.textures.exists(key)) {
+          this.displayImage(key, item);
+        } else {
+          this.showImage(item);
+        }
+      });
+      return;
+    }
+
+    this.scene.load.image(key, item.path); // 动态加载图片
+    const onFileComplete = (loadedKey: string, fileType: string) => {
+      if (loadedKey === key && fileType === 'image') {
+        this.scene.load.off(Phaser.Loader.Events.FILE_COMPLETE, onFileComplete);
+        this.displayImage(key, item);
+      }
+    };
+    this.scene.load.on(Phaser.Loader.Events.FILE_COMPLETE, onFileComplete);
+    this.scene.load.start();
+  }
+
+  /**
+   * 使用已加载的纹理创建图片对象，并根据面板尺寸调整缩放。
+   */
+  private displayImage(textureKey: string, item: ResourcePreviewItem): void {
+    this.clearImage();
+    const image = this.scene.add.image(this.bounds.width / 2, this.bounds.height / 2 + 20, textureKey);
+    image.setOrigin(0.5, 0.5);
+    this.root.add(image);
+
+    const texture = this.scene.textures.get(textureKey);
+    const source = texture.getSourceImage() as { width: number; height: number };
+    const maxWidth = this.bounds.width - 24;
+    const maxHeight = this.bounds.height - 96;
+    const width = source?.width ?? maxWidth;
+    const height = source?.height ?? maxHeight;
+    const scale = Math.min(maxWidth / width, maxHeight / height, 1);
+    image.setScale(scale);
+
+    this.currentImage = image;
+    this.updateLabels(item, '图像');
+    this.currentPreviewType = 'image';
+    this.currentPath = item.path;
+  }
+
+  /**
+   * 预览音频：创建或更新 HTMLAudioElement，并通过 DOMElement 嵌入场景。
+   */
+  private showAudio(item: ResourcePreviewItem): void {
+    this.clearImage();
+    const { element, dom } = this.ensureAudioElement();
+    element.pause();
+    element.src = item.path;
+    element.load();
+    dom.setVisible(true);
+    this.updateLabels(item, '音频');
+    this.currentPreviewType = 'audio';
+    this.currentPath = item.path;
+  }
+
+  /**
+   * 更新顶部文本，显示路径和类型。
+   */
+  private updateLabels(item: ResourcePreviewItem, typeLabel: string): void {
+    this.pathText.setText(`路径：${item.path}`);
+    this.typeText.setText(`类型：${typeLabel} / ${item.type}`);
+  }
+
+  /**
+   * 确保音频 DOMElement 已创建，如未创建则生成新的元素并添加到场景。
+   */
+  private ensureAudioElement(): { element: HTMLAudioElement; dom: Phaser.GameObjects.DOMElement } {
+    if (this.audioElement && this.audioDom) {
+      return { element: this.audioElement, dom: this.audioDom };
+    }
+    const audio = document.createElement('audio');
+    audio.controls = true;
+    audio.preload = 'none';
+    audio.controlsList = 'nodownload noplaybackrate';
+    audio.classList.add('resource-browser-audio');
+
+    const dom = this.scene.add.dom(this.bounds.width / 2, this.bounds.height - 40, audio);
+    dom.setOrigin(0.5, 0.5);
+    this.root.add(dom);
+
+    this.audioElement = audio;
+    this.audioDom = dom;
+    return { element: audio, dom };
+  }
+
+  /**
+   * 暂停并隐藏音频播放控件，若 force 为 true 则彻底销毁。
+   */
+  private hideAudio(force = false): void {
+    if (!this.audioElement || !this.audioDom) {
+      return;
+    }
+    this.audioElement.pause();
+    this.audioElement.currentTime = 0;
+    if (force) {
+      this.audioDom.destroy();
+      this.audioElement = undefined;
+      this.audioDom = undefined;
+    } else {
+      this.audioDom.setVisible(false);
+    }
+  }
+
+  /**
+   * 清理当前图片对象。
+   */
+  private clearImage(): void {
+    if (this.currentImage) {
+      this.currentImage.destroy();
+      this.currentImage = undefined;
+    }
+  }
+
+  /**
+   * 根据路径生成或获取纹理键，避免重复加载。
+   */
+  private getTextureKey(path: string): string {
+    const existing = this.textureKeyMap.get(path);
+    if (existing) {
+      return existing;
+    }
+    const key = `resource-preview-${this.textureKeyMap.size}`;
+    this.textureKeyMap.set(path, key);
+    return key;
+  }
+
+  /**
+   * 返回当前正在展示的资源路径，供调试或测试使用。
+   */
+  public getCurrentPath(): string | null {
+    return this.currentPath;
+  }
+}
+

--- a/frontend/miniworld/src/ui/styles/resource_browser.css
+++ b/frontend/miniworld/src/ui/styles/resource_browser.css
@@ -1,0 +1,18 @@
+/* 资源浏览器专用样式：仅影响音频控件的外观 */
+.resource-browser-audio {
+  width: 180px;
+  max-width: 220px;
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 6px;
+  padding: 4px;
+}
+
+.resource-browser-audio::-webkit-media-controls-panel {
+  background: rgba(0, 0, 0, 0.55);
+}
+
+.resource-browser-audio::-webkit-media-controls-play-button,
+.resource-browser-audio::-webkit-media-controls-pause-button {
+  color: #ffffff;
+}
+

--- a/frontend/miniworld/test/ui/test_resource_browser.spec.ts
+++ b/frontend/miniworld/test/ui/test_resource_browser.spec.ts
@@ -1,0 +1,161 @@
+import Phaser from 'phaser'; // 引入Phaser类型
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'; // 引入测试工具
+import ResourceBrowserScene from '../../src/ui/ResourceBrowserScene'; // 待测试场景
+import type { ResourceListPanelAPI, ResourceListPanelConfig } from '../../src/ui/ResourceListPanel'; // 列表面板接口
+import type {
+  ResourcePreviewPanelAPI,
+  ResourcePreviewPanelConfig,
+  ResourceIndex,
+  ResourceCategory,
+  ResourcePreviewItem,
+} from '../../src/ui/ResourcePreviewPanel'; // 预览面板接口与类型
+
+const sampleIndex: ResourceIndex = {
+  images: [
+    { type: 'tiles', path: 'assets/build/tiles/World_A1.png' },
+    { type: 'ui', path: 'assets/build/ui/Tower1.png' },
+  ],
+  audio: [
+    { type: 'bgm', path: 'assets/build/audio/bgm/Town1.ogg' },
+  ],
+}; // 构造简化示例数据
+
+class FakeListPanel implements ResourceListPanelAPI {
+  public categories: ResourceCategory[] = [];
+  public lastCategory: ResourceCategory;
+  private readonly onCategoryChange: (category: ResourceCategory) => void;
+  private readonly onItemSelected: (category: ResourceCategory, item: ResourcePreviewItem) => void;
+
+  public constructor(config: ResourceListPanelConfig) {
+    this.onCategoryChange = config.onCategoryChange;
+    this.onItemSelected = config.onItemSelected;
+    this.lastCategory = config.initialCategory;
+  }
+
+  public setResources(index: ResourceIndex): void {
+    this.categories = (['images', 'audio'] as ResourceCategory[]).filter((category) => index[category] !== undefined);
+  }
+
+  public setActiveCategory(category: ResourceCategory): void {
+    this.lastCategory = category;
+    this.onCategoryChange(category);
+  }
+
+  public clearSelection(): void {
+    // 测试桩无需实现
+  }
+
+  public getTabLabels(): string[] {
+    return this.categories.map((category) => (category === 'images' ? 'Images' : 'Audio'));
+  }
+
+  public destroy(): void {
+    // 测试桩无需实现
+  }
+
+  public simulateSelect(category: ResourceCategory, item: ResourcePreviewItem): void {
+    this.onItemSelected(category, item);
+  }
+}
+
+class FakePreviewPanel implements ResourcePreviewPanelAPI {
+  public lastCategory: ResourceCategory | null = null;
+  public lastItem: ResourcePreviewItem | null = null;
+  public cleared = 0;
+
+  public showResource(category: ResourceCategory, item: ResourcePreviewItem): void {
+    this.lastCategory = category;
+    this.lastItem = item;
+  }
+
+  public clearPreview(): void {
+    this.cleared += 1;
+    this.lastCategory = null;
+    this.lastItem = null;
+  }
+
+  public getCurrentPreviewType(): 'image' | 'audio' | null {
+    if (!this.lastCategory) {
+      return null;
+    }
+    return this.lastCategory === 'images' ? 'image' : 'audio';
+  }
+
+  public destroy(): void {
+    // 测试桩无需实现
+  }
+}
+
+class TestResourceBrowserScene extends ResourceBrowserScene {
+  public fakeList!: FakeListPanel;
+  public fakePreview!: FakePreviewPanel;
+
+  public bootstrapForTests(): void {
+    const keyboard = {
+      addKey: vi.fn(() => ({ on: vi.fn(), destroy: vi.fn() })),
+      removeKey: vi.fn(),
+    };
+    Object.defineProperty(this, 'events', { value: new Phaser.Events.EventEmitter(), configurable: true });
+    Object.defineProperty(this, 'scale', { value: { width: 320, height: 320 }, configurable: true });
+    Object.defineProperty(this, 'cameras', { value: { main: { setBackgroundColor: vi.fn() } }, configurable: true });
+    Object.defineProperty(this, 'input', { value: { keyboard }, configurable: true });
+  }
+
+  protected override buildStaticUI(): void {
+    // 测试环境不需要渲染静态UI
+  }
+
+  protected override createListPanel(config: ResourceListPanelConfig): ResourceListPanelAPI {
+    this.fakeList = new FakeListPanel(config);
+    return this.fakeList;
+  }
+
+  protected override createPreviewPanel(config: ResourcePreviewPanelConfig): ResourcePreviewPanelAPI {
+    void config;
+    this.fakePreview = new FakePreviewPanel();
+    return this.fakePreview;
+  }
+}
+
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('ResourceBrowserScene', () => {
+  it('loads preview_index.json successfully', async () => {
+    const scene = new TestResourceBrowserScene();
+    scene.bootstrapForTests();
+    const mockResponse = { ok: true, json: async () => sampleIndex } as Response;
+    globalThis.fetch = vi.fn(async () => mockResponse) as typeof fetch;
+    scene.create();
+    await scene.reloadResources();
+    expect(scene.getLoadedCounts()).toEqual({ images: 2, audio: 1 });
+  });
+
+  it('renders both image and audio tabs', () => {
+    const scene = new TestResourceBrowserScene();
+    scene.bootstrapForTests();
+    scene.create();
+    scene['handleDataLoaded'](sampleIndex);
+    expect(scene.getTabLabels()).toEqual(['Images', 'Audio']);
+  });
+
+  it('updates preview panel on selection', () => {
+    const scene = new TestResourceBrowserScene();
+    scene.bootstrapForTests();
+    scene.create();
+    scene['handleDataLoaded'](sampleIndex);
+    scene.fakeList.setActiveCategory('audio');
+    expect(scene.fakePreview.cleared).toBeGreaterThanOrEqual(1);
+    scene.fakeList.simulateSelect('audio', sampleIndex.audio[0]);
+    expect(scene.fakePreview.lastItem?.path).toBe(sampleIndex.audio[0].path);
+    expect(scene.getCurrentPreviewType()).toBe('audio');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add a ResourceBrowser scene with list and preview panels to inspect entries from assets/preview_index.json on demand
- wire the new scene into the game startup flow, world hotkey prompts, and Makefile preview target
- cover the scene behaviour with Vitest cases that validate loading, tab rendering, and preview updates

## Testing
- pnpm --filter miniworld test *(fails: pnpm not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e9f03075908328939b04da60697ce2