### PR TITLE
Add resource manager scene with metadata editing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: miniworld-dev miniworld-build miniworld-test user-import user-import-move user-import-rules user-preview build-all miniworld-preview
+.PHONY: miniworld-dev miniworld-build miniworld-test user-import user-import-move user-import-rules user-preview build-all miniworld-preview miniworld-manager # 声明新增命令
 
 miniworld-dev:
 	pnpm --filter miniworld dev
@@ -10,7 +10,10 @@ miniworld-test:
 	pnpm --filter miniworld test
 
 miniworld-preview:
-	pnpm --filter miniworld dev -- --scene=ResourceBrowser
+        pnpm --filter miniworld dev -- --scene=ResourceBrowser
+
+miniworld-manager: # 启动素材管理器场景
+        pnpm --filter miniworld dev -- --scene=ResourceManager # 通过命令行参数进入管理器
 
 user-import:
 	python3 scripts/import_user_assets.py

--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ python -m http.server 8000
 - `make user-import`：调用 Python 脚本将 `assets/user_imports/` 复制到 `assets/build/`，生成 `index.json`，并保持所有操作为纯文本。
 - `make user-preview`：快速重建 `assets/preview_index.json`，并在 `logs/user_imports.log` 中写入明细，便于 Phaser 端调试。
 
+### 素材管理器（只读二进制）
+
+- 入口：在游戏内按下 `M`，或执行 `make miniworld-manager` 直接打开 `ResourceManagerScene`。
+- 功能：基于 `assets/preview_index.json` 构建资源列表，支持搜索、类型与标签筛选、批量添加标签/集合，并可编辑描述。
+- 数据存储：所有修改写入 `assets/metadata/tags.json`、`assets/metadata/descriptions.json`、`assets/metadata/collections.json`，均为纯文本 JSON，不生成任何二进制文件。
+- AI 建议：调用前端 `AiDescribeStub` 依据文件名与类别生成“离线规则”描述，需手动点击保存后才会写入 JSON。
+- 安全性：只读取 `assets/build/**` 现有文件，不生成缩略图、不对音频执行转码，控制台会输出 `✅ ResourceManager initialized (text-only)`、`✅ Metadata loaded/saved via JSON`、`✅ No binary generated` 以便审计。
+
 加载顺序：
 
 1. `@sharedAssets` → 指向仓库根的 `assets/user_imports/`

--- a/assets/metadata/collections.json
+++ b/assets/metadata/collections.json
@@ -1,0 +1,7 @@
+{
+  "starter-pack": [
+    "images:ui/IconSet.png",
+    "images:characters/animals.png",
+    "audio:audio/bgm/bgm_battle.ogg"
+  ]
+}

--- a/assets/metadata/descriptions.json
+++ b/assets/metadata/descriptions.json
@@ -1,0 +1,5 @@
+{
+  "images:characters/Actor1.png": "8人角色行走图（3x4 帧），RPG Maker MV/MZ 标准布局。",
+  "images:effects/Fire3.png": "火焰特效序列图（逐帧）。",
+  "audio:audio/se/sfx_attack.ogg": "近战攻击音效（短促）。"
+}

--- a/assets/metadata/tags.json
+++ b/assets/metadata/tags.json
@@ -1,0 +1,5 @@
+{
+  "images:characters/Actor1.png": ["npc", "human", "pack:actor"],
+  "images:effects/Fire3.png": ["effect", "fire"],
+  "audio:audio/se/sfx_attack.ogg": ["sfx", "combat"]
+}

--- a/frontend/miniworld/src/config/keys.ts
+++ b/frontend/miniworld/src/config/keys.ts
@@ -17,3 +17,4 @@ export const KEY_BUILD_MODE = 'U'; // 建造模式切换键
 export const KEY_BUILD_APPROVE = 'Y'; // 建造审批通过键
 export const KEY_BUILD_REJECT = 'N'; // 建造审批拒绝键
 export const KEY_RESOURCE_BROWSER = 'R'; // 资源浏览器键
+export const KEY_RESOURCE_MANAGER = 'M'; // 素材管理器键

--- a/frontend/miniworld/src/core/AiDescribeStub.ts
+++ b/frontend/miniworld/src/core/AiDescribeStub.ts
@@ -1,0 +1,42 @@
+export interface DescribeTarget { // 定义输入对象接口
+  type: string; // 资源类型字段
+  path: string; // 资源路径字段
+} // 接口结束
+
+function extractFileName(path: string): string { // 提取文件名的辅助函数
+  const segments = path.split('/'); // 使用斜杠分割路径
+  return segments[segments.length - 1] ?? path; // 返回最后一段或原路径
+} // 函数结束
+
+function describeDomain(type: string, path: string): string { // 根据类型与路径生成域描述
+  if (type === 'audio' || /\/audio\//.test(path)) { // 判断是否属于音频
+    return '音频'; // 返回音频描述
+  } // 条件结束
+  return '图像'; // 默认归类为图像
+} // 函数结束
+
+function describeCategory(type: string): string { // 根据细分类型生成说明
+  if (type.includes('bgm')) { // 如果含有bgm标签
+    return '背景音乐'; // 返回背景音乐说明
+  } // 条件结束
+  if (type.includes('se') || type.includes('sfx')) { // 判断音效
+    return '音效'; // 返回音效说明
+  } // 条件结束
+  if (type.includes('character') || type.includes('actor')) { // 判断角色图像
+    return '角色立绘或行走图'; // 返回角色说明
+  } // 条件结束
+  if (type.includes('ui')) { // 判断UI资源
+    return '界面元素'; // 返回UI说明
+  } // 条件结束
+  return '通用素材'; // 默认说明
+} // 函数结束
+
+export class AiDescribeStub { // 定义AI描述占位类
+  public async suggestDescription(item: DescribeTarget): Promise<string> { // 提供异步描述方法
+    const fileName = extractFileName(item.path); // 获取文件名
+    const domain = describeDomain(item.type, item.path); // 获取域描述
+    const category = describeCategory(item.type); // 获取类别说明
+    const baseName = fileName.replace(/\.[^.]+$/, ''); // 去掉扩展名
+    return `${domain}（${category}）：${fileName} —— 适用于${baseName}相关的场景`; // 返回组合描述
+  } // 方法结束
+} // 类结束

--- a/frontend/miniworld/src/core/MetadataStore.ts
+++ b/frontend/miniworld/src/core/MetadataStore.ts
@@ -1,0 +1,84 @@
+import type { ResourcePreviewItem } from '../ui/ResourcePreviewPanel'; // 引入现有类型以复用路径结构
+
+export type MetadataTagMap = Record<string, string[]>; // 定义标签映射类型
+export type MetadataDescriptionMap = Record<string, string>; // 定义描述映射类型
+export type MetadataCollectionMap = Record<string, string[]>; // 定义集合映射类型
+
+export interface StoreState { // 定义整体存储状态接口
+  tags: MetadataTagMap; // 标签数据
+  descriptions: MetadataDescriptionMap; // 描述数据
+  collections: MetadataCollectionMap; // 集合数据
+} // 接口结束
+
+const TAGS_PATH = 'assets/metadata/tags.json'; // 标签文件路径常量
+const DESCRIPTIONS_PATH = 'assets/metadata/descriptions.json'; // 描述文件路径常量
+const COLLECTIONS_PATH = 'assets/metadata/collections.json'; // 集合文件路径常量
+
+async function readJson<T>(path: string): Promise<T | null> { // 封装读取JSON的函数
+  try { // 捕获网络异常
+    const response = await fetch(path, { method: 'GET', cache: 'no-cache' }); // 以GET读取文本JSON
+    if (!response.ok) { // 判断状态码
+      return null; // 失败时返回空
+    }
+    return (await response.json()) as T; // 成功时解析JSON
+  } catch (error) { // 捕获错误
+    console.warn(`MetadataStore readJson ${path} failed`, error); // 控制台提示读取失败
+    return null; // 出错时返回空
+  }
+} // 函数结束
+
+async function writeJson(path: string, data: unknown): Promise<void> { // 封装写入JSON的函数
+  const body = JSON.stringify(data, null, 2); // 将数据序列化为带缩进的字符串
+  const response = await fetch(path, { // 通过fetch发送PUT请求
+    method: 'PUT', // 采用PUT以覆盖文件
+    headers: { 'Content-Type': 'application/json' }, // 指定内容类型
+    body, // 携带文本内容
+  });
+  if (!response.ok) { // 判断请求是否成功
+    throw new Error(`Failed to write ${path}: HTTP ${response.status}`); // 抛出错误供上层捕获
+  }
+} // 函数结束
+
+export class MetadataStore { // 定义元数据存取类
+  public async loadAll(): Promise<StoreState> { // 统一加载全部文件
+    const [tags, descriptions, collections] = await Promise.all([ // 并行请求三个文件
+      readJson<MetadataTagMap>(TAGS_PATH), // 读取标签
+      readJson<MetadataDescriptionMap>(DESCRIPTIONS_PATH), // 读取描述
+      readJson<MetadataCollectionMap>(COLLECTIONS_PATH), // 读取集合
+    ]); // Promise结束
+    return { // 组装返回对象
+      tags: tags ?? {}, // 若缺失则回退空对象
+      descriptions: descriptions ?? {}, // 同上
+      collections: collections ?? {}, // 同上
+    }; // 返回存储状态
+  } // 方法结束
+
+  public async saveTags(map: MetadataTagMap): Promise<void> { // 保存标签
+    await writeJson(TAGS_PATH, map); // 调用统一写入方法
+  } // 方法结束
+
+  public async saveDescriptions(map: MetadataDescriptionMap): Promise<void> { // 保存描述
+    await writeJson(DESCRIPTIONS_PATH, map); // 调用统一写入方法
+  } // 方法结束
+
+  public async saveCollections(map: MetadataCollectionMap): Promise<void> { // 保存集合
+    await writeJson(COLLECTIONS_PATH, map); // 调用统一写入方法
+  } // 方法结束
+
+  public keyOf(item: { type: string; path: string } | ResourcePreviewItem): string { // 根据条目生成唯一键
+    const domain = this.detectDomain(item); // 判定资源所属域
+    const relative = this.stripPrefix(item.path); // 去除assets/build前缀
+    return `${domain}:${relative}`; // 拼接键值
+  } // 方法结束
+
+  private detectDomain(item: { type: string; path: string }): 'images' | 'audio' { // 推断域名
+    if (item.type === 'audio' || /\/audio\//.test(item.path)) { // 如果类型为音频或路径含audio
+      return 'audio'; // 返回音频域
+    } // 条件结束
+    return 'images'; // 默认归类到图像域
+  } // 方法结束
+
+  private stripPrefix(path: string): string { // 去除公共路径前缀
+    return path.replace(/^assets\/build\//, ''); // 移除assets/build/，保持统一
+  } // 方法结束
+} // 类结束

--- a/frontend/miniworld/src/game.ts
+++ b/frontend/miniworld/src/game.ts
@@ -5,6 +5,7 @@ import UIScene from './scenes/UIScene'; // 引入UI场景
 import GlossaryScene from './ui/glossary/GlossaryScene'; // 引入图鉴场景
 import AchievementScene from './ui/achievements/AchievementScene'; // 引入成就场景
 import ResourceBrowserScene from './ui/ResourceBrowserScene'; // 引入资源浏览器场景
+import ResourceManagerScene from './ui/ResourceManagerScene'; // 引入素材管理器场景
 import { PIXEL_CONFIG } from './config/pixel'; // 引入像素渲染配置
 // 分隔注释 // 保持行有注释
 export function createMiniWorldGame(): Phaser.Game { // 导出创建游戏实例的函数
@@ -14,7 +15,7 @@ export function createMiniWorldGame(): Phaser.Game { // 导出创建游戏实例
     height: 320, // 设置游戏高度
     parent: 'app', // 挂载到页面上的节点
     backgroundColor: '#1d1f21', // 设置背景颜色
-    scene: [BootScene, WorldScene, UIScene, GlossaryScene, AchievementScene, ResourceBrowserScene], // 注册场景顺序
+    scene: [BootScene, WorldScene, UIScene, GlossaryScene, AchievementScene, ResourceBrowserScene, ResourceManagerScene], // 注册场景顺序
     scale: { mode: Phaser.Scale.FIT, autoCenter: Phaser.Scale.CENTER_BOTH, zoom: 2 }, // 缩放与居中设置
     dom: { createContainer: true }, // 启用DOM容器以嵌入音频控件
     render: {

--- a/frontend/miniworld/src/scenes/BootScene.ts
+++ b/frontend/miniworld/src/scenes/BootScene.ts
@@ -20,9 +20,12 @@ export default class BootScene extends Phaser.Scene { // 定义启动场景
     } // 条件结束
     const requested = (window as typeof window & { __MINIWORLD_START_SCENE__?: string }).__MINIWORLD_START_SCENE__;
     const normalized = requested?.toLowerCase() ?? '';
-    let target: string = 'WorldScene';
-    if (normalized === 'resourcebrowser' || normalized === 'resourcebrowserscene') {
-      target = 'ResourceBrowserScene';
+    let target: string = 'WorldScene'; // 默认进入世界场景
+    if (normalized === 'resourcebrowser' || normalized === 'resourcebrowserscene') { // 判断资源浏览器参数
+      target = 'ResourceBrowserScene'; // 切换到浏览器
+    }
+    if (normalized === 'resourcemanager' || normalized === 'resourcemanagerscene') { // 判断素材管理器参数
+      target = 'ResourceManagerScene'; // 切换到素材管理器
     }
     this.scene.start(target); // 根据参数切换到目标场景
   } // 方法结束

--- a/frontend/miniworld/src/scenes/WorldScene.ts
+++ b/frontend/miniworld/src/scenes/WorldScene.ts
@@ -1,5 +1,5 @@
 import Phaser from 'phaser'; // 引入Phaser框架
-import { KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT, KEY_INTERACT, KEY_SAVE, KEY_LOAD, KEY_GLOSSARY, KEY_ACHIEVEMENT, KEY_SHOP, KEY_SPEED_TOGGLE, KEY_JOURNAL, KEY_BUILD_MODE, KEY_BUILD_APPROVE, KEY_BUILD_REJECT, KEY_RESOURCE_BROWSER } from '../config/keys'; // 引入按键常量
+import { KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT, KEY_INTERACT, KEY_SAVE, KEY_LOAD, KEY_GLOSSARY, KEY_ACHIEVEMENT, KEY_SHOP, KEY_SPEED_TOGGLE, KEY_JOURNAL, KEY_BUILD_MODE, KEY_BUILD_APPROVE, KEY_BUILD_REJECT, KEY_RESOURCE_BROWSER, KEY_RESOURCE_MANAGER } from '../config/keys'; // 引入按键常量
 import { genDemoMap, isWalkable, layerOf } from '../world/TileRules'; // 引入地图工具
 import { TileCell, GridPos } from '../world/Types'; // 引入类型定义
 import { getNodeAt, removeNodeAt } from '../world/Nodes'; // 引入资源节点接口
@@ -61,6 +61,7 @@ export default class WorldScene extends Phaser.Scene { // 定义世界场景
   private shopKey!: Phaser.Input.Keyboard.Key; // 商店交互键
   private speedKey!: Phaser.Input.Keyboard.Key; // 快进切换键
   private resourceBrowserKey!: Phaser.Input.Keyboard.Key; // 资源浏览器快捷键
+  private resourceManagerKey!: Phaser.Input.Keyboard.Key; // 素材管理器快捷键
   private hudScene?: UIScene; // UI场景引用
   private pendingTimeState?: ReturnType<TimeSystem['serialize']>; // 待恢复时间数据
   private pendingShopState?: ReturnType<ShopStore['toJSON']>; // 待恢复商店数据
@@ -379,6 +380,10 @@ export default class WorldScene extends Phaser.Scene { // 定义世界场景
     this.resourceBrowserKey.on('down', () => { // 监听资源浏览器键按下
       this.openResourceBrowser(); // 打开资源浏览器
     }); // 监听结束
+    this.resourceManagerKey = this.input.keyboard.addKey(KEY_RESOURCE_MANAGER); // 创建素材管理器键
+    this.resourceManagerKey.on('down', () => { // 监听素材管理器键按下
+      this.openResourceManager(); // 打开素材管理器
+    }); // 监听结束
     this.buildToggleKey = this.input.keyboard.addKey(KEY_BUILD_MODE); // 创建建造模式键
     this.buildToggleKey.on('down', () => { // 监听建造模式键按下
       this.toggleBuildMode(); // 切换建造模式
@@ -414,7 +419,7 @@ export default class WorldScene extends Phaser.Scene { // 定义世界场景
     const source = this.registry.get('assetSource') as string | undefined; // 读取素材来源
     this.hudSourceText = this.add.text(8, 8, `素材来源：${source ?? '占位纹理'}`, { fontFamily: 'sans-serif', fontSize: '12px', color: '#ffffff', backgroundColor: 'rgba(0,0,0,0.66)', padding: { x: 4, y: 2 } }); // 创建左上角文本
     this.hudSourceText.setDepth(1200); // 设置渲染深度
-    this.hudControlsText = this.add.text(312, 312, 'Z 采集 / U 建造 / Ctrl+Z 撤销 / Ctrl+Y 重做 / Y 审批 / N 拒绝 / E 商店 / J 日志 / Shift 倍速 / A 自动 / S 保存或跳过 / L 读取 / G 图鉴 / H 成就 / R 资源浏览器', { fontFamily: 'sans-serif', fontSize: '12px', color: '#ffffff', backgroundColor: 'rgba(0,0,0,0.66)', padding: { x: 4, y: 2 }, align: 'right' }); // 创建右下角提示
+    this.hudControlsText = this.add.text(312, 312, 'Z 采集 / U 建造 / Ctrl+Z 撤销 / Ctrl+Y 重做 / Y 审批 / N 拒绝 / E 商店 / J 日志 / Shift 倍速 / A 自动 / S 保存或跳过 / L 读取 / G 图鉴 / H 成就 / R 资源浏览器 / M 素材管理器', { fontFamily: 'sans-serif', fontSize: '12px', color: '#ffffff', backgroundColor: 'rgba(0,0,0,0.66)', padding: { x: 4, y: 2 }, align: 'right' }); // 创建右下角提示
     this.hudControlsText.setOrigin(1, 1); // 设置锚点
     this.hudControlsText.setDepth(1200); // 设置深度
   } // 方法结束
@@ -1174,6 +1179,11 @@ export default class WorldScene extends Phaser.Scene { // 定义世界场景
   private openResourceBrowser(): void { // 打开资源浏览器
     this.scene.pause(); // 暂停世界
     this.scene.launch('ResourceBrowserScene'); // 启动资源浏览器
+  } // 方法结束
+  // 分隔注释 // 保持行有注释
+  private openResourceManager(): void { // 打开素材管理器
+    this.scene.pause(); // 暂停世界
+    this.scene.launch('ResourceManagerScene'); // 启动素材管理器
   } // 方法结束
   // 分隔注释 // 保持行有注释
   private openAchievementScene(): void { // 打开成就场景

--- a/frontend/miniworld/src/ui/ResourceManagerScene.ts
+++ b/frontend/miniworld/src/ui/ResourceManagerScene.ts
@@ -1,0 +1,251 @@
+import Phaser from 'phaser'; // 引入Phaser框架
+import './styles/resource_manager.css'; // 引入素材管理器样式
+import type { ResourceIndex, ResourcePreviewItem } from './ResourcePreviewPanel'; // 引入预览索引类型
+import { FilterPanel, type FilterCriteria } from './panels/FilterPanel'; // 引入过滤面板
+import { ListPanel, type ResourceListItem } from './panels/ListPanel'; // 引入列表面板
+import { DetailPanel } from './panels/DetailPanel'; // 引入详情面板
+import { MetadataStore, type StoreState } from '../core/MetadataStore'; // 引入元数据存取
+import { AiDescribeStub } from '../core/AiDescribeStub'; // 引入AI占位
+
+export interface ResourceManagerItem { // 定义资源管理器条目结构
+  key: string; // 唯一键
+  type: 'images' | 'audio'; // 分类域
+  path: string; // 完整路径
+  name: string; // 文件名
+  searchText: string; // 搜索字段
+} // 接口结束
+
+export function deriveDomain(entry: ResourcePreviewItem): 'images' | 'audio' | null { // 根据条目推断域
+  if (/\/audio\//.test(entry.path)) { // 如果路径包含audio
+    return 'audio'; // 判定为音频
+  } // 条件结束
+  if (/\/images\//.test(entry.path)) { // 如果路径包含images
+    return 'images'; // 判定为图像
+  } // 条件结束
+  return null; // 其余情况忽略
+} // 函数结束
+
+export function buildManagerItems(index: ResourceIndex, store: MetadataStore): ResourceManagerItem[] { // 从索引构建条目
+  const items: ResourceManagerItem[] = []; // 初始化数组
+  index.images?.forEach((entry) => { // 遍历图片
+    const domain = deriveDomain(entry); // 推断域
+    if (domain === 'images') { // 确认域有效
+      const key = store.keyOf(entry); // 生成键
+      const name = entry.path.split('/').pop() ?? entry.path; // 提取文件名
+      items.push({ key, type: domain, path: entry.path, name, searchText: `${name.toLowerCase()} ${entry.path.toLowerCase()}` }); // 加入数组
+    } // 条件结束
+  }); // 循环结束
+  index.audio?.forEach((entry) => { // 遍历音频
+    const domain = deriveDomain(entry); // 推断域
+    if (domain === 'audio') { // 确认域有效
+      const key = store.keyOf(entry); // 生成键
+      const name = entry.path.split('/').pop() ?? entry.path; // 提取文件名
+      items.push({ key, type: domain, path: entry.path, name, searchText: `${name.toLowerCase()} ${entry.path.toLowerCase()}` }); // 加入数组
+    } // 条件结束
+  }); // 循环结束
+  return items; // 返回结果
+} // 函数结束
+
+export function filterManagerItems(items: ResourceManagerItem[], metadata: StoreState, criteria: FilterCriteria): ResourceManagerItem[] { // 根据条件筛选
+  return items.filter((item) => { // 使用数组过滤
+    if (criteria.type !== 'all' && item.type !== criteria.type) { // 类型不匹配
+      return false; // 排除
+    } // 条件结束
+    if (criteria.q) { // 若有关键字
+      const query = criteria.q.toLowerCase(); // 转为小写
+      if (!item.searchText.includes(query)) { // 如果不包含
+        return false; // 排除
+      } // 条件结束
+    } // 条件结束
+    if (criteria.tags.length > 0) { // 若选择标签
+      const tags = metadata.tags[item.key] ?? []; // 获取标签
+      const missing = criteria.tags.some((tag) => !tags.includes(tag)); // 判断是否缺少
+      if (missing) { // 如果缺少
+        return false; // 排除
+      } // 条件结束
+    } // 条件结束
+    return true; // 保留条目
+  }); // 过滤结束
+} // 函数结束
+
+export default class ResourceManagerScene extends Phaser.Scene { // 定义素材管理器场景
+  private filterPanel?: FilterPanel; // 过滤面板引用
+  private listPanel?: ListPanel; // 列表面板引用
+  private detailPanel?: DetailPanel; // 详情面板引用
+  private store!: MetadataStore; // 元数据存储实例
+  private aiStub!: AiDescribeStub; // AI占位实例
+  private items: ResourceManagerItem[] = []; // 全量条目
+  private metadata: StoreState = { tags: {}, descriptions: {}, collections: {} }; // 当前元数据
+  private currentSelection: string | null = null; // 当前选中的键
+  private domRoot?: Phaser.GameObjects.DOMElement; // DOM容器引用
+  private escKey?: Phaser.Input.Keyboard.Key; // ESC键引用
+
+  public constructor() { // 构造函数
+    super('ResourceManagerScene'); // 指定场景名称
+  } // 构造结束
+
+  public create(): void { // 创建生命周期
+    console.info('✅ ResourceManager initialized (text-only)'); // 输出初始化日志
+    this.cameras.main.setBackgroundColor('rgba(0,0,0,0.75)'); // 设置背景
+    this.createBackdrop(); // 创建背景矩形
+    this.store = new MetadataStore(); // 实例化存储
+    this.aiStub = new AiDescribeStub(); // 实例化AI占位
+    this.buildPanels(); // 构建面板
+    this.registerShutdown(); // 注册销毁钩子
+    this.setupEscapeKey(); // 绑定ESC
+    void this.loadData(); // 异步加载数据
+  } // 方法结束
+
+  private createBackdrop(): void { // 创建背景
+    const overlay = this.add.rectangle(0, 0, this.scale.width, this.scale.height, 0x000000, 0.6); // 创建矩形
+    overlay.setOrigin(0, 0); // 设定原点
+  } // 方法结束
+
+  private buildPanels(): void { // 构建面板
+    const rootElement = document.createElement('div'); // 创建根DOM
+    rootElement.className = 'resource-manager-root'; // 设置样式
+    this.domRoot = this.add.dom(0, 0, rootElement); // 创建Phaser DOM元素
+    this.domRoot.setOrigin(0, 0); // 设定原点
+    this.filterPanel = new FilterPanel(rootElement); // 实例化过滤面板
+    this.listPanel = new ListPanel(rootElement, { // 实例化列表面板
+      onSelectionChange: (item) => this.handleSelectionChange(item), // 绑定选择回调
+      onBulkAddTag: (items, tag) => void this.handleBulkTag(items, tag), // 绑定批量标签
+      onBulkAddCollection: (items, collection) => void this.handleBulkCollection(items, collection), // 绑定批量集合
+    }); // 构造结束
+    this.detailPanel = new DetailPanel(rootElement); // 实例化详情面板
+    this.detailPanel.setHandlers({ // 绑定详情回调
+      onSave: (payload) => void this.handleSaveMetadata(payload), // 保存回调
+      onRequestAi: (item) => this.aiStub.suggestDescription({ type: item.type, path: item.path }), // AI回调
+    }); // 设置结束
+    this.filterPanel.setOnChange((criteria) => this.applyFilter(criteria)); // 绑定筛选变更
+  } // 方法结束
+
+  private async loadData(): Promise<void> { // 异步加载数据
+    try { // 捕获异常
+      const previewResponse = await fetch('assets/preview_index.json', { method: 'GET', cache: 'no-cache' }); // 读取预览索引
+      if (!previewResponse.ok) { // 判断响应
+        throw new Error(`preview_index.json ${previewResponse.status}`); // 抛出错误
+      } // 条件结束
+      const manifest = (await previewResponse.json()) as ResourceIndex; // 解析JSON
+      this.metadata = await this.store.loadAll(); // 读取元数据
+      console.info('✅ Metadata loaded/saved via JSON'); // 输出日志
+      this.items = buildManagerItems(manifest, this.store); // 构建条目
+      this.refreshAvailableTags(); // 更新标签选项
+      this.applyFilter(this.filterPanel?.getCriteria() ?? { q: '', type: 'all', tags: [] }); // 首次过滤
+      console.info('✅ No binary generated'); // 输出无二进制日志
+    } catch (error) { // 捕获异常
+      console.error('ResourceManagerScene loadData failed', error); // 输出错误
+    } // 条件结束
+  } // 方法结束
+
+  private refreshAvailableTags(): void { // 更新标签选项
+    if (!this.filterPanel) { // 如果面板未创建
+      return; // 直接返回
+    } // 条件结束
+    const tagSet = new Set<string>(); // 创建集合
+    Object.values(this.metadata.tags).forEach((tags) => tags.forEach((tag) => tagSet.add(tag))); // 收集标签
+    this.filterPanel.setAvailableTags(Array.from(tagSet)); // 更新面板
+  } // 方法结束
+
+  private applyFilter(criteria: FilterCriteria): void { // 应用筛选
+    const filtered = filterManagerItems(this.items, this.metadata, criteria); // 获取筛选结果
+    const listItems: ResourceListItem[] = filtered.map((item) => ({ // 映射列表项
+      key: item.key, // 复制键
+      type: item.type, // 复制类型
+      path: item.path, // 复制路径
+      name: item.name, // 复制名称
+      tags: this.metadata.tags[item.key] ?? [], // 读取标签
+    })); // 映射结束
+    this.listPanel?.setItems(listItems); // 更新列表
+    if (this.currentSelection) { // 若存在选中
+      const stillExists = listItems.find((entry) => entry.key === this.currentSelection); // 查找是否保留
+      if (!stillExists) { // 如果不存在
+        this.currentSelection = null; // 清空选中
+        this.detailPanel?.showItem(null, [], ''); // 清空详情
+      } // 条件结束
+    } // 条件结束
+  } // 方法结束
+
+  private handleSelectionChange(item: ResourceListItem | null): void { // 处理选择变更
+    this.currentSelection = item?.key ?? null; // 记录选中键
+    const tags = item ? this.metadata.tags[item.key] ?? [] : []; // 获取标签
+    const description = item ? this.metadata.descriptions[item.key] ?? '' : ''; // 获取描述
+    this.detailPanel?.showItem(item, tags, description); // 更新详情
+  } // 方法结束
+
+  private async handleSaveMetadata(payload: { item: ResourceListItem; tags: string[]; description: string }): Promise<void> { // 保存元数据
+    this.metadata.tags[payload.item.key] = payload.tags; // 更新标签映射
+    this.metadata.descriptions[payload.item.key] = payload.description; // 更新描述映射
+    await Promise.all([ // 并行写入
+      this.store.saveTags(this.metadata.tags), // 保存标签
+      this.store.saveDescriptions(this.metadata.descriptions), // 保存描述
+    ]); // Promise结束
+    console.info('✅ Metadata loaded/saved via JSON'); // 输出保存日志
+    this.refreshAvailableTags(); // 更新标签列表
+    this.applyFilter(this.filterPanel?.getCriteria() ?? { q: '', type: 'all', tags: [] }); // 刷新列表
+  } // 方法结束
+
+  private async handleBulkTag(items: ResourceListItem[], tag: string): Promise<void> { // 批量添加标签
+    items.forEach((item) => { // 遍历条目
+      const list = this.metadata.tags[item.key] ?? []; // 获取现有标签
+      if (!list.includes(tag)) { // 若不存在
+        list.push(tag); // 添加标签
+        this.metadata.tags[item.key] = list; // 回写映射
+      } // 条件结束
+    }); // 循环结束
+    await this.store.saveTags(this.metadata.tags); // 保存标签
+    console.info('✅ Metadata loaded/saved via JSON'); // 输出保存日志
+    this.refreshAvailableTags(); // 更新标签列表
+    this.applyFilter(this.filterPanel?.getCriteria() ?? { q: '', type: 'all', tags: [] }); // 刷新列表
+  } // 方法结束
+
+  private async handleBulkCollection(items: ResourceListItem[], collection: string): Promise<void> { // 批量加入集合
+    const trimmed = collection.trim(); // 处理空格
+    if (!trimmed) { // 如果集合名为空
+      return; // 直接返回
+    } // 条件结束
+    const existing = this.metadata.collections[trimmed] ?? []; // 获取现有集合
+    const keys = new Set(existing); // 转换为集合
+    items.forEach((item) => { // 遍历条目
+      if (!keys.has(item.key)) { // 如果集合中没有
+        existing.push(item.key); // 添加键
+        keys.add(item.key); // 更新集合
+      } // 条件结束
+    }); // 循环结束
+    this.metadata.collections[trimmed] = existing; // 回写集合
+    await this.store.saveCollections(this.metadata.collections); // 保存集合
+    console.info('✅ Metadata loaded/saved via JSON'); // 输出保存日志
+  } // 方法结束
+
+  private registerShutdown(): void { // 注册销毁逻辑
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => { // 监听关闭
+      this.domRoot?.destroy(); // 销毁DOM容器
+      this.domRoot = undefined; // 重置引用
+      this.filterPanel = undefined; // 清空面板
+      this.listPanel = undefined; // 清空列表
+      this.detailPanel = undefined; // 清空详情
+      if (this.escKey) { // 如果存在ESC
+        this.input.keyboard?.removeKey(this.escKey); // 移除键位
+        this.escKey = undefined; // 清空引用
+      } // 条件结束
+    }); // 事件结束
+  } // 方法结束
+
+  private setupEscapeKey(): void { // 设置ESC关闭
+    const keyboard = this.input.keyboard; // 获取键盘
+    if (!keyboard) { // 若无键盘
+      return; // 直接返回
+    } // 条件结束
+    this.escKey = keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ESC); // 注册ESC键
+    this.escKey.on('down', () => this.exitScene()); // 绑定按下事件
+  } // 方法结束
+
+  private exitScene(): void { // 退出场景
+    this.scene.stop(); // 停止当前场景
+    if (this.scene.isPaused('WorldScene')) { // 如果世界场景被暂停
+      this.scene.resume('WorldScene'); // 恢复世界场景
+    } else if (!this.scene.isActive('WorldScene')) { // 如果世界场景未激活
+      this.scene.start('WorldScene'); // 启动世界场景
+    } // 条件结束
+  } // 方法结束
+} // 类结束

--- a/frontend/miniworld/src/ui/panels/DetailPanel.ts
+++ b/frontend/miniworld/src/ui/panels/DetailPanel.ts
@@ -1,0 +1,177 @@
+import './styles/resource_manager.css'; // 引入样式文件
+import type { ResourceListItem } from './ListPanel'; // 引入列表项类型供复用
+
+export interface DetailPanelHandlers { // 定义回调接口
+  onSave: (payload: { item: ResourceListItem; tags: string[]; description: string }) => void; // 保存元数据
+  onRequestAi: (item: ResourceListItem) => Promise<string>; // 请求AI建议
+} // 接口结束
+
+export class DetailPanel { // 定义详情面板类
+  private readonly root: HTMLDivElement; // 根容器
+  private readonly title: HTMLHeadingElement; // 标题元素
+  private readonly preview: HTMLDivElement; // 预览容器
+  private readonly tagList: HTMLDivElement; // 标签列表容器
+  private readonly tagInput: HTMLInputElement; // 标签输入框
+  private readonly descriptionArea: HTMLTextAreaElement; // 描述文本域
+  private readonly saveButton: HTMLButtonElement; // 保存按钮
+  private readonly aiButton: HTMLButtonElement; // AI按钮
+  private currentItem: ResourceListItem | null = null; // 当前条目
+  private currentTags: string[] = []; // 当前标签
+  private handlers?: DetailPanelHandlers; // 回调引用
+
+  public constructor(container: HTMLElement) { // 构造函数
+    this.root = document.createElement('div'); // 创建根容器
+    this.root.className = 'resource-manager-detail'; // 设置样式
+    container.appendChild(this.root); // 挂载面板
+
+    this.title = document.createElement('h3'); // 创建标题
+    this.title.textContent = '请选择资源'; // 初始文案
+    this.root.appendChild(this.title); // 添加标题
+
+    this.preview = document.createElement('div'); // 创建预览容器
+    this.preview.className = 'resource-manager-preview'; // 设置样式
+    this.root.appendChild(this.preview); // 添加容器
+
+    const tagSection = document.createElement('div'); // 创建标签区域
+    const tagHeader = document.createElement('div'); // 创建标签标题
+    tagHeader.textContent = '标签'; // 设置文本
+    tagSection.appendChild(tagHeader); // 添加标题
+
+    this.tagList = document.createElement('div'); // 创建标签列表
+    this.tagList.className = 'resource-manager-tag-list'; // 设置样式
+    tagSection.appendChild(this.tagList); // 添加列表
+
+    const tagInputRow = document.createElement('div'); // 创建输入行
+    tagInputRow.style.display = 'flex'; // 使用flex
+    tagInputRow.style.gap = '6px'; // 设置间距
+    this.tagInput = document.createElement('input'); // 创建输入框
+    this.tagInput.placeholder = '输入新标签后回车'; // 设置提示
+    this.tagInput.addEventListener('keydown', (event) => { // 绑定键盘事件
+      if (event.key === 'Enter') { // 判断是否回车
+        event.preventDefault(); // 阻止默认行为
+        this.appendTagFromInput(); // 添加标签
+      } // 条件结束
+    }); // 事件结束
+    tagInputRow.appendChild(this.tagInput); // 添加输入框
+
+    const tagAddButton = document.createElement('button'); // 创建添加按钮
+    tagAddButton.textContent = '添加'; // 设置文本
+    tagAddButton.addEventListener('click', () => this.appendTagFromInput()); // 绑定点击
+    tagInputRow.appendChild(tagAddButton); // 添加按钮
+
+    tagSection.appendChild(tagInputRow); // 将输入行加入区域
+    this.root.appendChild(tagSection); // 添加整个标签区域
+
+    const descriptionLabel = document.createElement('label'); // 创建描述标题
+    descriptionLabel.textContent = '描述'; // 设置文本
+    this.root.appendChild(descriptionLabel); // 添加标题
+
+    this.descriptionArea = document.createElement('textarea'); // 创建描述输入
+    this.descriptionArea.rows = 6; // 设置行数
+    this.root.appendChild(this.descriptionArea); // 添加文本域
+
+    const buttonRow = document.createElement('div'); // 创建按钮行
+    buttonRow.style.display = 'flex'; // 使用flex
+    buttonRow.style.gap = '8px'; // 设置间距
+
+    this.saveButton = document.createElement('button'); // 创建保存按钮
+    this.saveButton.textContent = '保存元数据'; // 设置文本
+    this.saveButton.addEventListener('click', () => this.handleSave()); // 绑定点击
+    buttonRow.appendChild(this.saveButton); // 添加按钮
+
+    this.aiButton = document.createElement('button'); // 创建AI按钮
+    this.aiButton.textContent = 'AI 建议（离线规则）'; // 设置文本
+    this.aiButton.addEventListener('click', () => this.handleAi()); // 绑定点击
+    buttonRow.appendChild(this.aiButton); // 添加按钮
+
+    this.root.appendChild(buttonRow); // 添加按钮行
+  } // 构造结束
+
+  public setHandlers(handlers: DetailPanelHandlers): void { // 注入回调
+    this.handlers = handlers; // 存储回调
+  } // 方法结束
+
+  public showItem(item: ResourceListItem | null, tags: string[], description: string): void { // 展示条目
+    this.currentItem = item; // 保存引用
+    this.currentTags = [...tags]; // 复制标签
+    if (!item) { // 若为空
+      this.title.textContent = '请选择资源'; // 更新标题
+      this.preview.innerHTML = '<span>暂无预览</span>'; // 显示提示
+      this.renderTags(); // 渲染空标签
+      this.descriptionArea.value = ''; // 清空描述
+      return; // 结束
+    } // 条件结束
+    this.title.textContent = `${item.type.toUpperCase()} · ${item.path}`; // 更新标题
+    this.renderPreview(item); // 渲染预览
+    this.renderTags(); // 渲染标签
+    this.descriptionArea.value = description; // 设置描述
+  } // 方法结束
+
+  private renderPreview(item: ResourceListItem): void { // 渲染预览
+    this.preview.innerHTML = ''; // 清空旧内容
+    if (item.type === 'images') { // 如果是图像
+      const img = document.createElement('img'); // 创建图片
+      img.src = item.path; // 指定路径
+      img.alt = item.name; // 设置提示
+      this.preview.appendChild(img); // 添加图片
+    } else { // 否则视为音频
+      const audio = document.createElement('audio'); // 创建音频控件
+      audio.controls = true; // 启用控制条
+      audio.src = item.path; // 指定路径
+      this.preview.appendChild(audio); // 添加控件
+    } // 条件结束
+  } // 方法结束
+
+  private renderTags(): void { // 渲染标签列表
+    this.tagList.innerHTML = ''; // 清空容器
+    this.currentTags.forEach((tag) => { // 遍历标签
+      const tagItem = document.createElement('div'); // 创建标签元素
+      tagItem.className = 'resource-manager-tag'; // 设置样式
+      const text = document.createElement('span'); // 创建文本节点
+      text.textContent = tag; // 设置文本
+      tagItem.appendChild(text); // 添加文本
+      const remove = document.createElement('button'); // 创建删除按钮
+      remove.textContent = '×'; // 设置符号
+      remove.addEventListener('click', () => { // 绑定点击
+        this.currentTags = this.currentTags.filter((entry) => entry !== tag); // 移除标签
+        this.renderTags(); // 重新渲染
+      }); // 事件结束
+      tagItem.appendChild(remove); // 添加按钮
+      this.tagList.appendChild(tagItem); // 将标签加入列表
+    }); // 循环结束
+  } // 方法结束
+
+  private appendTagFromInput(): void { // 通过输入框添加标签
+    const value = this.tagInput.value.trim(); // 读取输入
+    if (!value) { // 如果为空
+      return; // 直接返回
+    } // 条件结束
+    if (!this.currentTags.includes(value)) { // 如果尚未存在
+      this.currentTags.push(value); // 添加标签
+      this.renderTags(); // 刷新列表
+    } // 条件结束
+    this.tagInput.value = ''; // 清空输入框
+  } // 方法结束
+
+  private handleSave(): void { // 处理保存操作
+    if (!this.currentItem || !this.handlers) { // 若缺少条目或回调
+      return; // 直接返回
+    } // 条件结束
+    const payload = { // 组装数据
+      item: this.currentItem, // 当前条目
+      tags: [...this.currentTags], // 当前标签
+      description: this.descriptionArea.value.trim(), // 描述文本
+    }; // 对象结束
+    this.handlers.onSave(payload); // 调用回调
+  } // 方法结束
+
+  private async handleAi(): Promise<void> { // 处理AI建议
+    if (!this.currentItem || !this.handlers) { // 若缺少必要信息
+      return; // 直接返回
+    } // 条件结束
+    const suggestion = await this.handlers.onRequestAi(this.currentItem); // 调用外部AI
+    if (suggestion) { // 如果返回文本
+      this.descriptionArea.value = suggestion; // 填充描述
+    } // 条件结束
+  } // 方法结束
+} // 类结束

--- a/frontend/miniworld/src/ui/panels/FilterPanel.ts
+++ b/frontend/miniworld/src/ui/panels/FilterPanel.ts
@@ -1,0 +1,100 @@
+import './styles/resource_manager.css'; // 引入样式确保控件风格一致
+
+export type ResourceTypeFilter = 'all' | 'images' | 'audio'; // 定义类型筛选的取值范围
+
+export interface FilterCriteria { // 定义筛选条件接口
+  q: string; // 模糊搜索关键词
+  type: ResourceTypeFilter; // 类型过滤
+  tags: string[]; // 标签过滤
+} // 接口结束
+
+export type FilterChangeHandler = (criteria: FilterCriteria) => void; // 定义筛选回调类型
+
+export class FilterPanel { // 定义过滤面板类
+  private readonly root: HTMLDivElement; // 根容器
+  private readonly searchInput: HTMLInputElement; // 搜索输入框
+  private readonly typeSelect: HTMLSelectElement; // 类型选择框
+  private readonly tagSelect: HTMLSelectElement; // 标签多选框
+  private onChange?: FilterChangeHandler; // 回调引用
+
+  public constructor(container: HTMLElement) { // 构造函数接收父容器
+    this.root = document.createElement('div'); // 创建根容器
+    this.root.className = 'resource-manager-filter'; // 设定样式类
+    container.appendChild(this.root); // 挂载到父容器
+
+    const title = document.createElement('h3'); // 创建标题
+    title.textContent = '筛选'; // 设置文本
+    this.root.appendChild(title); // 添加到面板
+
+    this.searchInput = document.createElement('input'); // 创建搜索框
+    this.searchInput.type = 'search'; // 指定类型
+    this.searchInput.placeholder = '搜索名称或路径'; // 设置提示
+    this.root.appendChild(this.searchInput); // 添加控件
+
+    this.typeSelect = document.createElement('select'); // 创建类型选择
+    const options: Array<{ value: ResourceTypeFilter; label: string }> = [ // 定义选项
+      { value: 'all', label: '全部类型' }, // 全部项
+      { value: 'images', label: '图像' }, // 图像项
+      { value: 'audio', label: '音频' }, // 音频项
+    ]; // 数组结束
+    options.forEach((entry) => { // 遍历选项
+      const option = document.createElement('option'); // 创建option
+      option.value = entry.value; // 设置值
+      option.textContent = entry.label; // 设置文本
+      this.typeSelect.appendChild(option); // 加入下拉框
+    }); // 循环结束
+    this.root.appendChild(this.typeSelect); // 添加到面板
+
+    const tagLabel = document.createElement('label'); // 创建标签标题
+    tagLabel.textContent = '标签筛选'; // 设置文字
+    this.root.appendChild(tagLabel); // 添加到面板
+
+    this.tagSelect = document.createElement('select'); // 创建多选框
+    this.tagSelect.multiple = true; // 启用多选
+    this.tagSelect.size = 6; // 显示六行
+    this.root.appendChild(this.tagSelect); // 添加控件
+
+    [this.searchInput, this.typeSelect, this.tagSelect].forEach((element) => { // 绑定事件
+      element.addEventListener('input', () => this.emitChange()); // 输入时触发
+      element.addEventListener('change', () => this.emitChange()); // 变更时触发
+    }); // 循环结束
+  } // 构造结束
+
+  public setAvailableTags(tags: string[]): void { // 更新可选标签
+    const previousSelection = this.getSelectedTags(); // 记录当前选择
+    this.tagSelect.innerHTML = ''; // 清空旧选项
+    tags.sort((a, b) => a.localeCompare(b)); // 排序标签
+    tags.forEach((tag) => { // 遍历标签
+      const option = document.createElement('option'); // 创建option
+      option.value = tag; // 设置值
+      option.textContent = tag; // 设置文本
+      if (previousSelection.includes(tag)) { // 如果之前已选择
+        option.selected = true; // 保持选择
+      } // 条件结束
+      this.tagSelect.appendChild(option); // 添加到多选框
+    }); // 循环结束
+    this.emitChange(); // 通知外部刷新
+  } // 方法结束
+
+  public setOnChange(handler: FilterChangeHandler): void { // 设置回调
+    this.onChange = handler; // 存储回调
+  } // 方法结束
+
+  public getCriteria(): FilterCriteria { // 获取当前筛选条件
+    return { // 返回对象
+      q: this.searchInput.value.trim(), // 获取搜索词
+      type: this.typeSelect.value as ResourceTypeFilter, // 获取类型选择
+      tags: this.getSelectedTags(), // 获取已选标签
+    }; // 返回结束
+  } // 方法结束
+
+  private getSelectedTags(): string[] { // 内部方法读取多选值
+    return Array.from(this.tagSelect.selectedOptions).map((option) => option.value); // 转换为数组
+  } // 方法结束
+
+  private emitChange(): void { // 触发回调
+    if (this.onChange) { // 确认回调存在
+      this.onChange(this.getCriteria()); // 传出当前条件
+    } // 条件结束
+  } // 方法结束
+} // 类结束

--- a/frontend/miniworld/src/ui/panels/ListPanel.ts
+++ b/frontend/miniworld/src/ui/panels/ListPanel.ts
@@ -1,0 +1,154 @@
+import './styles/resource_manager.css'; // 引入样式确保布局一致
+
+export interface ResourceListItem { // 定义列表项数据结构
+  key: string; // 唯一键值
+  type: 'images' | 'audio'; // 资源域
+  path: string; // 完整路径
+  name: string; // 文件名
+  tags: string[]; // 已有标签
+} // 接口结束
+
+export interface ListPanelHandlers { // 定义事件回调
+  onSelectionChange: (item: ResourceListItem | null) => void; // 单选变化
+  onBulkAddTag: (items: ResourceListItem[], tag: string) => void; // 批量添加标签
+  onBulkAddCollection: (items: ResourceListItem[], collection: string) => void; // 批量加入集合
+} // 接口结束
+
+export class ListPanel { // 定义列表面板类
+  private readonly root: HTMLDivElement; // 根容器
+  private readonly actions: HTMLDivElement; // 批量操作容器
+  private readonly scroll: HTMLDivElement; // 滚动区域
+  private items: ResourceListItem[] = []; // 当前列表数据
+  private selectedKeys: Set<string> = new Set(); // 当前选中项集合
+  private activeKey: string | null = null; // 用于高亮的主选项
+
+  public constructor(container: HTMLElement, private readonly handlers: ListPanelHandlers) { // 构造函数
+    this.root = document.createElement('div'); // 创建根容器
+    this.root.className = 'resource-manager-list'; // 应用样式
+    container.appendChild(this.root); // 挂载到父容器
+
+    const header = document.createElement('div'); // 创建标题容器
+    header.textContent = '资源列表'; // 设置标题
+    this.root.appendChild(header); // 添加到面板
+
+    this.actions = document.createElement('div'); // 创建操作区域
+    this.actions.className = 'resource-manager-actions'; // 设置样式
+    this.root.appendChild(this.actions); // 添加到面板
+
+    const tagButton = document.createElement('button'); // 创建批量标签按钮
+    tagButton.textContent = '批量添加标签'; // 设置文本
+    tagButton.addEventListener('click', () => this.requestBulkTag()); // 绑定点击事件
+    this.actions.appendChild(tagButton); // 添加按钮
+
+    const collectionButton = document.createElement('button'); // 创建批量集合按钮
+    collectionButton.textContent = '批量加入集合'; // 设置文本
+    collectionButton.addEventListener('click', () => this.requestBulkCollection()); // 绑定事件
+    this.actions.appendChild(collectionButton); // 添加按钮
+
+    this.scroll = document.createElement('div'); // 创建滚动容器
+    this.scroll.className = 'resource-manager-list-scroll'; // 设置样式
+    this.root.appendChild(this.scroll); // 添加到面板
+  } // 构造结束
+
+  public setItems(items: ResourceListItem[]): void { // 更新列表数据
+    this.items = items; // 存储数据
+    const existing = new Set(this.selectedKeys); // 保留当前选择
+    this.selectedKeys = new Set(items.filter((item) => existing.has(item.key)).map((item) => item.key)); // 交叉保留
+    if (this.activeKey && !this.selectedKeys.has(this.activeKey)) { // 如果当前高亮不在列表
+      this.activeKey = null; // 重置主选项
+    } // 条件结束
+    this.render(); // 重新渲染
+  } // 方法结束
+
+  public getSelectedItems(): ResourceListItem[] { // 暴露当前选中项
+    return this.items.filter((item) => this.selectedKeys.has(item.key)); // 根据集合过滤
+  } // 方法结束
+
+  public clearSelection(): void { // 清空选择
+    this.selectedKeys.clear(); // 清除集合
+    this.activeKey = null; // 重置主选
+    this.render(); // 刷新界面
+    this.handlers.onSelectionChange(null); // 通知外部
+  } // 方法结束
+
+  private render(): void { // 渲染列表
+    this.scroll.innerHTML = ''; // 清空旧内容
+    this.items.forEach((item) => { // 遍历资源
+      const row = document.createElement('div'); // 创建行
+      row.className = 'resource-manager-row'; // 设置样式
+      if (item.key === this.activeKey) { // 如果为主选项
+        row.classList.add('active'); // 添加高亮
+      } // 条件结束
+
+      const checkbox = document.createElement('input'); // 创建复选框
+      checkbox.type = 'checkbox'; // 设置类型
+      checkbox.checked = this.selectedKeys.has(item.key); // 恢复选中状态
+      checkbox.addEventListener('change', () => { // 监听变化
+        if (checkbox.checked) { // 如果勾选
+          this.selectedKeys.add(item.key); // 加入集合
+        } else { // 否则
+          this.selectedKeys.delete(item.key); // 移除集合
+        } // 条件结束
+        this.handlers.onSelectionChange(this.resolveActiveItem()); // 通知外部当前主选
+      }); // 事件结束
+      row.appendChild(checkbox); // 添加复选框
+
+      const name = document.createElement('div'); // 创建名称元素
+      name.textContent = item.name; // 显示文件名
+      name.style.flex = '1'; // 占据剩余空间
+      row.appendChild(name); // 添加名称
+
+      const typeBadge = document.createElement('span'); // 创建类型徽章
+      typeBadge.className = 'resource-manager-badge'; // 设置样式
+      typeBadge.textContent = item.type === 'audio' ? '音频' : '图像'; // 设置文本
+      row.appendChild(typeBadge); // 添加徽章
+
+      const tagBadge = document.createElement('span'); // 创建标签数量徽章
+      tagBadge.className = 'resource-manager-badge'; // 设置样式
+      tagBadge.textContent = `${item.tags.length} 标签`; // 显示数量
+      row.appendChild(tagBadge); // 添加徽章
+
+      row.addEventListener('click', () => { // 监听整行点击
+        this.activeKey = item.key; // 设置主选项
+        this.selectedKeys.add(item.key); // 确保选中
+        this.handlers.onSelectionChange(item); // 通知外部
+        this.render(); // 重新渲染以更新高亮
+      }); // 事件结束
+
+      this.scroll.appendChild(row); // 将行加入列表
+    }); // 循环结束
+  } // 方法结束
+
+  private resolveActiveItem(): ResourceListItem | null { // 根据activeKey返回对象
+    if (!this.activeKey) { // 如果尚未设置主选项
+      return null; // 返回空
+    } // 条件结束
+    return this.items.find((item) => item.key === this.activeKey) ?? null; // 查找对应项
+  } // 方法结束
+
+  private requestBulkTag(): void { // 处理批量标签请求
+    const items = this.getSelectedItems(); // 获取选中项
+    if (items.length === 0) { // 无选择时
+      alert('请先选择要标记的资源'); // 提示用户
+      return; // 终止
+    } // 条件结束
+    const tag = window.prompt('输入要添加的标签'); // 弹出输入框
+    if (!tag) { // 若未输入
+      return; // 直接返回
+    } // 条件结束
+    this.handlers.onBulkAddTag(items, tag.trim()); // 调用回调
+  } // 方法结束
+
+  private requestBulkCollection(): void { // 处理批量集合请求
+    const items = this.getSelectedItems(); // 获取选中项
+    if (items.length === 0) { // 无选择时
+      alert('请先选择要加入集合的资源'); // 提示用户
+      return; // 终止
+    } // 条件结束
+    const name = window.prompt('输入集合名称'); // 弹出输入框
+    if (!name) { // 若未输入
+      return; // 直接返回
+    } // 条件结束
+    this.handlers.onBulkAddCollection(items, name.trim()); // 调用回调
+  } // 方法结束
+} // 类结束

--- a/frontend/miniworld/src/ui/styles/resource_manager.css
+++ b/frontend/miniworld/src/ui/styles/resource_manager.css
@@ -1,0 +1,162 @@
+/* 素材管理器根容器，使用半透明背景与flex布局 */
+.resource-manager-root { /* 根容器声明 */
+  position: absolute; /* 固定在画布左上 */
+  top: 48px; /* 顶部间距 */
+  left: 48px; /* 左侧间距 */
+  right: 48px; /* 右侧间距 */
+  bottom: 48px; /* 底部间距 */
+  display: flex; /* 使用flex布局 */
+  gap: 12px; /* 面板间距 */
+  color: #ffffff; /* 字体颜色 */
+  font-family: 'sans-serif'; /* 字体族 */
+  z-index: 2000; /* 保证覆盖 */
+}
+
+/* 左侧过滤面板样式 */
+.resource-manager-filter { /* 过滤面板类 */
+  width: 220px; /* 固定宽度 */
+  background: rgba(0, 0, 0, 0.65); /* 背景颜色 */
+  border: 1px solid rgba(255, 255, 255, 0.2); /* 边框 */
+  border-radius: 8px; /* 圆角 */
+  padding: 12px; /* 内边距 */
+  display: flex; /* 使用flex布局 */
+  flex-direction: column; /* 垂直排列 */
+  gap: 8px; /* 元素间距 */
+  overflow-y: auto; /* 内容溢出时滚动 */
+}
+
+/* 中部列表面板样式 */
+.resource-manager-list { /* 列表面板类 */
+  flex: 1; /* 占据剩余空间 */
+  background: rgba(0, 0, 0, 0.6); /* 背景颜色 */
+  border: 1px solid rgba(255, 255, 255, 0.2); /* 边框 */
+  border-radius: 8px; /* 圆角 */
+  padding: 12px; /* 内边距 */
+  display: flex; /* 使用flex布局 */
+  flex-direction: column; /* 垂直排列 */
+  gap: 8px; /* 元素间距 */
+  overflow: hidden; /* 隐藏溢出 */
+}
+
+/* 列表滚动区域样式 */
+.resource-manager-list-scroll { /* 列表滚动容器 */
+  flex: 1; /* 占满高度 */
+  overflow-y: auto; /* 允许滚动 */
+  background: rgba(255, 255, 255, 0.04); /* 淡色背景 */
+  border-radius: 6px; /* 圆角 */
+  padding: 8px; /* 内边距 */
+}
+
+/* 列表项样式 */
+.resource-manager-row { /* 单行容器 */
+  display: flex; /* 使用flex排列 */
+  align-items: center; /* 垂直居中 */
+  gap: 8px; /* 元素间距 */
+  padding: 4px 6px; /* 内边距 */
+  border-radius: 4px; /* 圆角 */
+}
+
+/* 列表项高亮状态 */
+.resource-manager-row.active { /* 激活状态类 */
+  background: rgba(0, 128, 255, 0.35); /* 高亮背景 */
+}
+
+/* 标签徽章样式 */
+.resource-manager-badge { /* 徽章类 */
+  background: rgba(255, 255, 255, 0.15); /* 背景颜色 */
+  color: #ffeeaa; /* 字体颜色 */
+  padding: 2px 6px; /* 内边距 */
+  border-radius: 6px; /* 圆角 */
+  font-size: 12px; /* 字号 */
+}
+
+/* 右侧详情面板样式 */
+.resource-manager-detail { /* 详情面板类 */
+  width: 320px; /* 固定宽度 */
+  background: rgba(0, 0, 0, 0.65); /* 背景颜色 */
+  border: 1px solid rgba(255, 255, 255, 0.2); /* 边框 */
+  border-radius: 8px; /* 圆角 */
+  padding: 12px; /* 内边距 */
+  display: flex; /* 使用flex布局 */
+  flex-direction: column; /* 垂直排列 */
+  gap: 10px; /* 元素间距 */
+  overflow-y: auto; /* 内容滚动 */
+}
+
+/* 预览容器样式 */
+.resource-manager-preview { /* 预览容器类 */
+  background: rgba(255, 255, 255, 0.05); /* 背景颜色 */
+  border-radius: 6px; /* 圆角 */
+  padding: 8px; /* 内边距 */
+  display: flex; /* 使用flex布局 */
+  justify-content: center; /* 水平居中 */
+  align-items: center; /* 垂直居中 */
+  min-height: 180px; /* 最小高度 */
+}
+
+/* 预览图片样式 */
+.resource-manager-preview img { /* 图片选择器 */
+  max-width: 100%; /* 限制宽度 */
+  max-height: 160px; /* 限制高度 */
+  image-rendering: pixelated; /* 像素化显示 */
+}
+
+/* 预览音频样式 */
+.resource-manager-preview audio { /* 音频控件 */
+  width: 100%; /* 占满宽度 */
+}
+
+/* 标签展示区域样式 */
+.resource-manager-tag-list { /* 标签列表容器 */
+  display: flex; /* 使用flex布局 */
+  flex-wrap: wrap; /* 自动换行 */
+  gap: 6px; /* 标签间距 */
+}
+
+/* 标签单元样式 */
+.resource-manager-tag { /* 标签项 */
+  background: rgba(0, 0, 0, 0.4); /* 背景颜色 */
+  border: 1px solid rgba(255, 255, 255, 0.2); /* 边框 */
+  border-radius: 12px; /* 圆角 */
+  padding: 2px 8px; /* 内边距 */
+  display: flex; /* 使用flex布局 */
+  gap: 4px; /* 图标间距 */
+  align-items: center; /* 垂直居中 */
+  font-size: 12px; /* 字号 */
+}
+
+/* 标签删除按钮样式 */
+.resource-manager-tag button { /* 删除按钮 */
+  background: transparent; /* 透明背景 */
+  border: none; /* 无边框 */
+  color: #ff9999; /* 字体颜色 */
+  cursor: pointer; /* 鼠标指针 */
+}
+
+/* 批量操作按钮样式 */
+.resource-manager-actions { /* 操作区域 */
+  display: flex; /* 使用flex布局 */
+  gap: 8px; /* 按钮间距 */
+  flex-wrap: wrap; /* 允许换行 */
+}
+
+.resource-manager-actions button { /* 操作按钮 */
+  background: rgba(0, 128, 255, 0.3); /* 背景颜色 */
+  border: 1px solid rgba(0, 128, 255, 0.6); /* 边框 */
+  color: #ffffff; /* 字体颜色 */
+  padding: 4px 8px; /* 内边距 */
+  border-radius: 6px; /* 圆角 */
+  cursor: pointer; /* 鼠标指针 */
+}
+
+/* 输入控件通用样式 */
+.resource-manager-root input, /* 输入选择器 */
+.resource-manager-root select, /* 下拉选择器 */
+.resource-manager-root textarea { /* 多行文本 */
+  background: rgba(0, 0, 0, 0.4); /* 背景颜色 */
+  border: 1px solid rgba(255, 255, 255, 0.2); /* 边框 */
+  border-radius: 6px; /* 圆角 */
+  color: #ffffff; /* 字体颜色 */
+  padding: 6px; /* 内边距 */
+  font-family: 'sans-serif'; /* 字体 */
+}

--- a/frontend/miniworld/test/ui/test_resource_manager.spec.ts
+++ b/frontend/miniworld/test/ui/test_resource_manager.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'; // 引入测试工具函数
+import { MetadataStore } from '../../../src/core/MetadataStore'; // 引入元数据存储类
+import { AiDescribeStub } from '../../../src/core/AiDescribeStub'; // 引入AI占位
+import ResourceManagerScene, { buildManagerItems, filterManagerItems, deriveDomain } from '../../../src/ui/ResourceManagerScene'; // 引入场景与工具函数
+
+const SAMPLE_INDEX = { // 构造预览索引样例
+  images: [ // 图像数组
+    { type: 'characters', path: 'assets/build/images/characters/Actor1.png' }, // 角色图
+    { type: 'effects', path: 'assets/build/images/effects/Fire3.png' }, // 特效图
+  ], // 数组结束
+  audio: [ // 音频数组
+    { type: 'bgm', path: 'assets/build/audio/bgm/Battle1.ogg' }, // 战斗BGM
+    { type: 'se', path: 'assets/build/audio/se/sfx_attack.ogg' }, // 攻击音效
+  ], // 数组结束
+}; // 样例结束
+
+describe('ResourceManagerScene helpers', () => { // 测试辅助函数分组
+  it('should derive domain from preview entries', () => { // 测试域推断
+    expect(deriveDomain({ type: 'foo', path: 'assets/build/images/foo.png' })).toBe('images'); // 校验图像
+    expect(deriveDomain({ type: 'foo', path: 'assets/build/audio/bar.ogg' })).toBe('audio'); // 校验音频
+    expect(deriveDomain({ type: 'foo', path: 'assets/build/tiles/foo.png' })).toBeNull(); // 非匹配返回空
+  }); // 用例结束
+
+  it('should build manager items from manifest', () => { // 测试构建条目
+    const store = new MetadataStore(); // 创建存储实例
+    const items = buildManagerItems(SAMPLE_INDEX, store); // 生成条目
+    expect(items).toHaveLength(4); // 应生成四条
+    const audioItem = items.find((item) => item.type === 'audio'); // 找到音频项
+    expect(audioItem?.key).toContain('audio:'); // 键应包含域前缀
+  }); // 用例结束
+
+  it('should filter items by criteria', () => { // 测试筛选
+    const store = new MetadataStore(); // 创建存储实例
+    const items = buildManagerItems(SAMPLE_INDEX, store); // 构造条目
+    const metadata = { // 构造元数据
+      tags: { [items[0].key]: ['npc'] }, // 第一条标签
+      descriptions: {}, // 描述为空
+      collections: {}, // 集合为空
+    }; // 对象结束
+    const filteredAll = filterManagerItems(items, metadata, { q: '', type: 'all', tags: [] }); // 不带条件
+    expect(filteredAll).toHaveLength(items.length); // 应保留全部
+    const filteredTag = filterManagerItems(items, metadata, { q: '', type: 'all', tags: ['npc'] }); // 按标签过滤
+    expect(filteredTag).toHaveLength(1); // 仅一条
+    const filteredType = filterManagerItems(items, metadata, { q: '', type: 'audio', tags: [] }); // 按类型过滤
+    expect(filteredType.every((item) => item.type === 'audio')).toBe(true); // 全为音频
+  }); // 用例结束
+}); // 描述结束
+
+describe('MetadataStore persistence', () => { // 测试存储读写
+  const originalFetch = globalThis.fetch; // 记录原始fetch
+  beforeEach(() => { // 每次测试前
+    vi.restoreAllMocks(); // 重置模拟
+  }); // 钩子结束
+  afterEach(() => { // 每次测试后
+    globalThis.fetch = originalFetch; // 还原fetch
+  }); // 钩子结束
+
+  it('should load empty when files missing', async () => { // 测试缺失文件
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false }); // 模拟失败响应
+    const store = new MetadataStore(); // 创建实例
+    const state = await store.loadAll(); // 加载数据
+    expect(state.tags).toEqual({}); // 标签为空
+    expect(state.descriptions).toEqual({}); // 描述为空
+    expect(state.collections).toEqual({}); // 集合为空
+  }); // 用例结束
+
+  it('should save maps via PUT requests', async () => { // 测试写入
+    const responses: Array<{ path: string; options: RequestInit }> = []; // 记录请求
+    globalThis.fetch = vi.fn((path: string, options?: RequestInit) => { // 模拟fetch
+      responses.push({ path, options: options ?? {} }); // 存储参数
+      return Promise.resolve({ ok: true }); // 返回成功
+    }) as typeof fetch; // 类型断言
+    const store = new MetadataStore(); // 创建实例
+    await store.saveTags({ foo: ['bar'] }); // 保存标签
+    await store.saveDescriptions({ foo: 'desc' }); // 保存描述
+    await store.saveCollections({ group: ['foo'] }); // 保存集合
+    expect(responses).toHaveLength(3); // 应调用三次
+    responses.forEach((entry) => { // 遍历请求
+      expect(entry.options?.method).toBe('PUT'); // 应为PUT
+      expect(typeof entry.options?.body).toBe('string'); // body为文本
+    }); // 循环结束
+  }); // 用例结束
+}); // 描述结束
+
+describe('AiDescribeStub', () => { // 测试AI占位
+  it('should return suggestion text', async () => { // 测试描述生成
+    const stub = new AiDescribeStub(); // 创建实例
+    const text = await stub.suggestDescription({ type: 'audio', path: 'assets/build/audio/se/sfx_attack.ogg' }); // 调用方法
+    expect(text).toContain('sfx_attack.ogg'); // 包含文件名
+  }); // 用例结束
+}); // 描述结束
+
+it('should expose scene class for registration', () => { // 测试场景导出
+  expect(typeof ResourceManagerScene).toBe('function'); // 类应为函数
+}); // 用例结束


### PR DESCRIPTION
## Summary
- add a Resource Manager scene with filter, list, and detail panels for managing asset metadata
- introduce MetadataStore and AiDescribeStub utilities with supporting styles and vitest coverage
- expose CLI entrypoints and documentation, including default metadata JSON files and UI hotkey

## Testing
- pnpm --filter miniworld test *(fails: vitest not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e9f96aba008328baaf2508a335423f