### PR TITLE
Add Gantt scheduler scene and tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: miniworld-dev miniworld-build miniworld-test user-import user-import-move user-import-rules user-preview build-all miniworld-preview miniworld-manager assets-analyze assets-rename-dry assets-rename-apply assets-rename-revert synth-defaults miniworld-auto hot-run auto-snapshot auto-rollback auto-snapshots agents-demo agents-log # 声明新增命令
+.PHONY: miniworld-dev miniworld-build miniworld-test user-import user-import-move user-import-rules user-preview build-all miniworld-preview miniworld-manager assets-analyze assets-rename-dry assets-rename-apply assets-rename-revert synth-defaults miniworld-auto hot-run auto-snapshot auto-rollback auto-snapshots agents-demo agents-log scheduler scheduler-snapshot scheduler-rollback scheduler-validate # 声明新增命令
 
 miniworld-dev:
 	pnpm --filter miniworld dev
@@ -19,7 +19,19 @@ miniworld-preview:
 	pnpm --filter miniworld dev -- --scene=ResourceBrowser
 
 miniworld-manager: # 启动素材管理器场景
-	pnpm --filter miniworld dev -- --scene=ResourceManager # 通过命令行参数进入管理器
+        pnpm --filter miniworld dev -- --scene=ResourceManager # 通过命令行参数进入管理器
+
+scheduler: # 启动甘特排程场景
+	pnpm --filter miniworld dev -- --scene=Gantt # 启动甘特视图
+
+scheduler-snapshot: # 手动生成排程快照
+	python3 scripts/snapshot_scheduler.py # 调用快照脚本
+
+scheduler-rollback: # 回滚排程到最新快照
+	python3 scripts/rollback_scheduler.py --latest # 调用回滚脚本
+
+scheduler-validate: # 校验排程文件合法性
+	python3 scripts/validate_scheduler.py # 调用校验脚本
 
 user-import:
 	python3 scripts/import_user_assets.py

--- a/assets/scheduler/scheduler.json
+++ b/assets/scheduler/scheduler.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "timeScale": "minutes",
+  "startAt": "2025-10-11T08:00:00Z",
+  "rows": [
+    { "id": "worker-1", "label": "工人#1" },
+    { "id": "worker-2", "label": "工人#2" }
+  ],
+  "tasks": [
+    {
+      "id": "task-000",
+      "type": "build",
+      "title": "建造：hut@(5,3)",
+      "rowId": "worker-1",
+      "start": "2025-10-11T08:30:00Z",
+      "durationMin": 60,
+      "deadline": "2025-10-11T12:00:00Z",
+      "payload": {
+        "type": "build",
+        "x": 5,
+        "y": 3,
+        "blueprintId": "hut"
+      },
+      "flags": ["priority_high"],
+      "status": "approved"
+    },
+    {
+      "id": "task-001",
+      "type": "build",
+      "title": "建造：tree@(10,5)",
+      "rowId": "worker-1",
+      "start": "2025-10-11T09:45:00Z",
+      "durationMin": 30,
+      "deadline": "2025-10-11T18:00:00Z",
+      "dependsOn": ["task-000"],
+      "payload": {
+        "type": "build",
+        "x": 10,
+        "y": 5,
+        "blueprintId": "tree"
+      },
+      "flags": ["quiet"],
+      "status": "planned"
+    }
+  ]
+}

--- a/assets/scheduler/snapshots/2025-10-11T12-30-05Z_scheduler.json
+++ b/assets/scheduler/snapshots/2025-10-11T12-30-05Z_scheduler.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "timeScale": "minutes",
+  "startAt": "2025-10-11T08:00:00Z",
+  "rows": [
+    { "id": "worker-1", "label": "工人#1" },
+    { "id": "worker-2", "label": "工人#2" }
+  ],
+  "tasks": []
+}

--- a/frontend/miniworld/src/config/SchedulerIO.ts
+++ b/frontend/miniworld/src/config/SchedulerIO.ts
@@ -1,0 +1,56 @@
+import { promises as fs } from 'fs'; // 引入文件读写接口
+import path from 'path'; // 引入路径工具
+import { execFile } from 'child_process'; // 引入子进程调用
+import { promisify } from 'util'; // 引入工具将回调转为 Promise
+import { SchedulerData } from '../scheduler/GanttLayout'; // 引入排程数据类型
+
+const execFileAsync = promisify(execFile); // 将 execFile 转换为 Promise 形式
+
+export class SchedulerIO { // 定义排程文件的读写工具
+  private readonly baseDir: string; // 保存白名单目录
+  private readonly filePath: string; // 保存主文件路径
+
+  public constructor(baseDir = path.resolve(process.cwd(), 'assets', 'scheduler'), fileName = 'scheduler.json') { // 构造函数
+    this.baseDir = baseDir; // 保存基础目录
+    this.filePath = path.resolve(this.baseDir, fileName); // 计算主文件路径
+    this.ensureWhitelist(this.filePath); // 检查路径安全
+  } // 构造结束
+
+  public async load(): Promise<SchedulerData> { // 读取排程文件
+    const content = await fs.readFile(this.filePath, 'utf8'); // 异步读取文本
+    const data = JSON.parse(content) as SchedulerData; // 解析 JSON
+    return data; // 返回数据
+  } // 方法结束
+
+  public async save(data: SchedulerData): Promise<void> { // 保存排程文件
+    await this.runValidate(); // 保存前执行校验脚本
+    const text = `${JSON.stringify(data, null, 2)}\n`; // 序列化为文本并保证换行
+    await fs.writeFile(this.filePath, text, 'utf8'); // 写入主文件
+    await this.runSnapshot(); // 写入后生成快照
+  } // 方法结束
+
+  public getPath(): string { // 获取主文件路径
+    return this.filePath; // 返回路径
+  } // 方法结束
+
+  private ensureWhitelist(target: string): void { // 确保目标路径在白名单内
+    if (!target.startsWith(this.baseDir)) { // 如果不在基础目录中
+      throw new Error(`Path not allowed: ${target}`); // 抛出错误
+    } // 条件结束
+    if (!target.endsWith('.json')) { // 如果后缀不是 JSON
+      throw new Error(`Only json files allowed: ${target}`); // 抛出错误
+    } // 条件结束
+  } // 方法结束
+
+  private async runSnapshot(): Promise<void> { // 调用快照脚本
+    await execFileAsync('python3', ['scripts/snapshot_scheduler.py']); // 使用子进程执行脚本
+  } // 方法结束
+
+  public async runRollback(args: string[] = ['--latest']): Promise<void> { // 暴露回滚功能
+    await execFileAsync('python3', ['scripts/rollback_scheduler.py', ...args]); // 调用回滚脚本
+  } // 方法结束
+
+  public async runValidate(): Promise<void> { // 触发校验脚本
+    await execFileAsync('python3', ['scripts/validate_scheduler.py']); // 调用校验脚本
+  } // 方法结束
+} // 类结束

--- a/frontend/miniworld/src/runtime/HotReloadBus.ts
+++ b/frontend/miniworld/src/runtime/HotReloadBus.ts
@@ -9,10 +9,17 @@ export interface RulesChangedPayload { // 声明规则数据变更事件的接�
   timestamp: number; // 记录规则变更的时间戳
 } // 接口结束
 
+// 扩展调度器变更事件负载
+export interface SchedulerChangedPayload { // 声明排程文件变更事件接口
+  path: string; // 触发变更的文件路径
+  timestamp: number; // 事件时间戳
+} // 接口结束
+
 // 声明允许订阅的事件名称常量集合
 export type HotReloadEventMap = { // 定义事件名称到负载的映射类型
   autoChanged: AutoChangedPayload; // 自动数据变更事件映射
   rulesChanged: RulesChangedPayload; // 规则数据变更事件映射
+  schedulerChanged: SchedulerChangedPayload; // 排程文件变更事件映射
 }; // 类型结束
 
 // 定义事件监听器函数类型
@@ -68,4 +75,9 @@ export function emitAutoChanged(diff: AutoChangedPayload): void { // 定义触�
 // 便捷导出以便触发规则变更事件
 export function emitRulesChanged(payload: RulesChangedPayload): void { // 定义触发规则事件的工具函数
   HotReloadBus.emit('rulesChanged', payload); // 调用总线触发规则事件
+} // 函数结束
+
+// 新增方法用于触发排程文件更新事件
+export function emitSchedulerChanged(payload: SchedulerChangedPayload): void { // 定义触发排程事件的工具函数
+  HotReloadBus.emit('schedulerChanged', payload); // 调用总线触发排程事件
 } // 函数结束

--- a/frontend/miniworld/src/scheduler/GanttDataBridge.ts
+++ b/frontend/miniworld/src/scheduler/GanttDataBridge.ts
@@ -1,0 +1,83 @@
+import { AgentAPI, AgentTask } from '../build/AgentAPI'; // 引入代理任务接口
+import { SchedulerData, SchedulerTask } from './GanttLayout'; // 引入排程数据类型
+import { SchedulerIO } from '../config/SchedulerIO'; // 引入存储工具
+
+export interface WorkerStatusEvent { // 描述工人状态事件
+  taskId: string; // 关联的任务 ID
+  status: string; // 最新状态
+  progress?: number; // 可选的进度百分比
+} // 结束接口
+
+export class GanttDataBridge { // 定义甘特图与执行系统之间的桥接器
+  private api: AgentAPI; // 保存 AgentAPI 引用
+  private io: SchedulerIO; // 保存排程 IO
+  private workerListeners = new Set<(event: WorkerStatusEvent) => void>(); // 存储工人事件监听器
+  private scheduler: SchedulerData | null = null; // 当前排程数据
+
+  public constructor(api: AgentAPI, io: SchedulerIO) { // 构造函数
+    this.api = api; // 记录 AgentAPI
+    this.io = io; // 记录 IO 工具
+  } // 构造结束
+
+  public setScheduler(data: SchedulerData): void { // 设置当前排程
+    this.scheduler = data; // 保存排程数据
+  } // 方法结束
+
+  public onWorkerEvent(handler: (event: WorkerStatusEvent) => void): void { // 允许外部监听工人事件
+    this.workerListeners.add(handler); // 添加监听器
+  } // 方法结束
+
+  public receiveWorkerEvent(event: WorkerStatusEvent): void { // 从工人处接收事件
+    if (!this.scheduler) { // 如果没有排程
+      return; // 直接返回
+    } // 条件结束
+    const task = this.scheduler.tasks.find((item) => item.id === event.taskId); // 查找任务
+    if (!task) { // 如果未找到
+      return; // 忽略
+    } // 条件结束
+    task.status = event.status; // 更新状态
+    if (event.progress !== undefined) { // 如果提供进度
+      task.progress = event.progress; // 写入进度
+    } // 条件结束
+    this.workerListeners.forEach((listener) => listener(event)); // 遍历监听器广播事件
+  } // 方法结束
+
+  public async sendForApproval(): Promise<SchedulerTask[]> { // 将待审批任务推送到 AgentAPI
+    if (!this.scheduler) { // 如果没有排程
+      throw new Error('Scheduler not loaded'); // 抛出异常
+    } // 条件结束
+    const promoted: SchedulerTask[] = []; // 记录已提交任务
+    for (const task of this.scheduler.tasks) { // 遍历任务
+      if (task.status !== 'planned') { // 若非计划状态
+        continue; // 跳过
+      } // 条件结束
+      if (!this.dependenciesSatisfied(task)) { // 如果依赖未满足
+        continue; // 跳过
+      } // 条件结束
+      const payload = task.payload as AgentTask | undefined; // 读取 payload
+      if (!payload) { // 如果没有负载
+        continue; // 跳过
+      } // 条件结束
+      this.api.submitTask(payload, { issuerRole: 'scheduler' }); // 提交到任务队列
+      task.status = 'approved'; // 更新状态
+      promoted.push(task); // 记录成功提交
+    } // 遍历结束
+    if (promoted.length > 0) { // 如果有提交
+      await this.io.save(this.scheduler); // 写回排程
+    } // 条件结束
+    return promoted; // 返回提交列表
+  } // 方法结束
+
+  private dependenciesSatisfied(task: SchedulerTask): boolean { // 判断依赖是否满足
+    if (!this.scheduler || !task.dependsOn || task.dependsOn.length === 0) { // 无依赖直接通过
+      return true; // 返回真
+    } // 条件结束
+    return task.dependsOn.every((id) => { // 检查每个依赖
+      const target = this.scheduler!.tasks.find((item) => item.id === id); // 查找依赖任务
+      if (!target) { // 如果依赖不存在
+        return false; // 无法满足
+      } // 条件结束
+      return target.status === 'approved' || target.status === 'executing' || target.status === 'done'; // 只有已审批或进行中或完成才视为满足
+    }); // 遍历结束
+  } // 方法结束
+} // 类结束

--- a/frontend/miniworld/src/scheduler/GanttInteraction.ts
+++ b/frontend/miniworld/src/scheduler/GanttInteraction.ts
@@ -1,0 +1,101 @@
+import { WorkCalendar } from '../time/WorkCalendar'; // 引入工作日历用于吸附规则
+import { GanttLayout, SchedulerData, SchedulerTask } from './GanttLayout'; // 引入布局与数据类型
+import { SchedulerIO } from '../config/SchedulerIO'; // 引入排程存储接口
+
+export class GanttInteraction { // 定义甘特交互控制器
+  private scheduler: SchedulerData; // 保存当前排程数据
+  private layout: GanttLayout; // 保存布局计算器
+  private calendar: WorkCalendar; // 保存工作日历
+  private io: SchedulerIO; // 保存读写工具
+  private selectedTaskId: string | null = null; // 当前选中的任务
+
+  public constructor(scheduler: SchedulerData, layout: GanttLayout, calendar: WorkCalendar, io: SchedulerIO) { // 构造函数
+    this.scheduler = scheduler; // 记录排程数据
+    this.layout = layout; // 记录布局工具
+    this.calendar = calendar; // 记录工作日历
+    this.io = io; // 记录存储工具
+  } // 构造结束
+
+  public selectTask(taskId: string | null): void { // 选择某个任务
+    this.selectedTaskId = taskId; // 更新选中状态
+  } // 方法结束
+
+  public dragTask(taskId: string, deltaMinutes: number): void { // 拖拽任务改变开始时间
+    const task = this.findTask(taskId); // 查找目标任务
+    const start = new Date(task.start); // 解析原始开始时间
+    const moved = new Date(start.getTime() + deltaMinutes * 60000); // 根据偏移计算新时间
+    const aligned = this.calendar.alignToNextSlot(moved); // 使用工作日历吸附到可执行时间
+    task.start = aligned.toISOString(); // 更新任务开始时间
+  } // 方法结束
+
+  public resizeTask(taskId: string, deltaMinutes: number): void { // 调整任务持续时间
+    const task = this.findTask(taskId); // 查找任务
+    const duration = this.extractDuration(task); // 读取当前持续分钟
+    const next = Math.max(15, duration + deltaMinutes); // 计算新的持续并限制最小值
+    if (this.scheduler.timeScale === 'hours') { // 如果排程以小时计
+      task.durationHr = next / 60; // 将分钟转换为小时字段
+      task.durationMin = undefined; // 清除分钟字段避免冲突
+    } else { // 否则
+      task.durationMin = next; // 直接写入分钟
+    } // 条件结束
+  } // 方法结束
+
+  public connectDependency(fromId: string, toId: string): void { // 创建依赖关系
+    const target = this.findTask(toId); // 找到目标任务
+    if (!target.dependsOn) { // 如果没有依赖数组
+      target.dependsOn = []; // 初始化数组
+    } // 条件结束
+    if (!target.dependsOn.includes(fromId)) { // 如果依赖中不存在该任务
+      target.dependsOn.push(fromId); // 添加依赖
+    } // 条件结束
+  } // 方法结束
+
+  public disconnectDependency(fromId: string, toId: string): void { // 移除依赖关系
+    const target = this.findTask(toId); // 查找目标任务
+    if (!target.dependsOn) { // 如果没有依赖
+      return; // 无需处理
+    } // 条件结束
+    target.dependsOn = target.dependsOn.filter((item) => item !== fromId); // 过滤掉指定依赖
+    if (target.dependsOn.length === 0) { // 如果数组为空
+      delete target.dependsOn; // 删除属性保持清爽
+    } // 条件结束
+  } // 方法结束
+
+  public duplicateSelected(): SchedulerTask | null { // 复制当前选中任务
+    if (!this.selectedTaskId) { // 若没有选中任务
+      return null; // 返回空
+    } // 条件结束
+    const source = this.findTask(this.selectedTaskId); // 查找源任务
+    const clone: SchedulerTask = { ...source, id: `${source.id}-copy-${Date.now()}`, start: this.calendar.alignToNextSlot(new Date(new Date(source.start).getTime() + this.extractDuration(source) * 60000)).toISOString(), status: 'planned' }; // 创建副本并顺延时间
+    this.scheduler.tasks.push(clone); // 添加到排程中
+    return clone; // 返回新任务
+  } // 方法结束
+
+  public async save(): Promise<void> { // 保存排程文件
+    await this.io.save(this.scheduler); // 调用 IO 保存
+  } // 方法结束
+
+  public getScheduler(): SchedulerData { // 获取当前排程
+    return this.scheduler; // 返回数据
+  } // 方法结束
+
+  private findTask(id: string): SchedulerTask { // 辅助方法：根据 ID 查找任务
+    const task = this.scheduler.tasks.find((item) => item.id === id); // 查找任务
+    if (!task) { // 如果未找到
+      throw new Error(`Task not found: ${id}`); // 抛出错误
+    } // 条件结束
+    return task; // 返回任务
+  } // 方法结束
+
+  private extractDuration(task: SchedulerTask): number { // 辅助方法：提取任务持续时间
+    if (this.scheduler.timeScale === 'hours') { // 如果时间单位是小时
+      if (task.durationHr !== undefined) { // 若存在小时字段
+        return task.durationHr * 60; // 转换成分钟
+      } // 条件结束
+    } // 条件结束
+    if (task.durationMin !== undefined) { // 如果存在分钟字段
+      return task.durationMin; // 直接返回
+    } // 条件结束
+    return 30; // 默认返回半小时
+  } // 方法结束
+} // 类结束

--- a/frontend/miniworld/src/scheduler/GanttLayout.ts
+++ b/frontend/miniworld/src/scheduler/GanttLayout.ts
@@ -1,0 +1,177 @@
+import { GANTT_STYLES, GanttStyles } from './GanttStyles'; // 引入样式常量便于换算
+
+export type SchedulerTimeScale = 'minutes' | 'hours'; // 定义排程支持的时间刻度
+
+export interface SchedulerRow { // 声明排程行的结构
+  id: string; // 行的唯一标识
+  label: string; // 行的显示标签
+} // 结束接口定义
+
+export interface SchedulerTask { // 声明排程任务的结构
+  id: string; // 任务唯一标识
+  type: string; // 任务类型
+  title: string; // 任务标题
+  rowId: string; // 所属行
+  start: string; // 开始时间（ISO 字符串）
+  durationMin?: number; // 分钟持续时间
+  durationHr?: number; // 小时持续时间
+  deadline?: string; // 截止时间
+  dependsOn?: string[]; // 依赖列表
+  payload?: Record<string, unknown>; // 任务附加数据
+  flags?: string[]; // 状态标记
+  status?: string; // 当前状态
+  progress?: number; // 执行进度
+} // 结束接口定义
+
+export interface SchedulerData { // 定义排程文件整体结构
+  version: number; // 版本号
+  timeScale: SchedulerTimeScale; // 时间刻度
+  startAt: string; // 时间轴起始点
+  rows: SchedulerRow[]; // 所有资源行
+  tasks: SchedulerTask[]; // 所有任务
+} // 结束接口定义
+
+export interface LayoutTask { // 描述渲染时需要的任务几何信息
+  task: SchedulerTask; // 原始任务对象
+  x: number; // 起始 x 坐标
+  y: number; // 起始 y 坐标
+  width: number; // 宽度（像素）
+  height: number; // 高度（像素）
+  rowIndex: number; // 所属行索引
+} // 结束接口定义
+
+export interface LayoutTick { // 描述时间刻度
+  x: number; // 刻度线的 x 坐标
+  label: string; // 显示标签
+  major: boolean; // 是否为主刻度
+} // 结束接口定义
+
+export interface LayoutResult { // 描述一次布局计算后的集合
+  tasks: LayoutTask[]; // 所有任务的布局信息
+  ticks: LayoutTick[]; // 时间刻度集合
+  rowPositions: Map<string, number>; // 行到 y 坐标的映射
+} // 结束接口定义
+
+export interface GanttLayoutOptions { // 布局配置项
+  viewportWidth: number; // 视口宽度
+  viewportHeight: number; // 视口高度
+  zoom: number; // 缩放倍数
+} // 结束接口定义
+
+export class GanttLayout { // 定义甘特布局核心类
+  private scheduler: SchedulerData; // 保存当前排程数据
+  private styles: GanttStyles; // 保存样式常量
+  private options: GanttLayoutOptions; // 保存视口与缩放配置
+  private startAt: Date; // 计算时的起始时间
+  private pixelsPerMinute: number; // 每分钟对应的像素
+
+  public constructor(scheduler: SchedulerData, options?: Partial<GanttLayoutOptions>, styles: GanttStyles = GANTT_STYLES) { // 构造函数
+    this.scheduler = scheduler; // 存储排程数据
+    this.styles = styles; // 存储样式配置
+    this.startAt = new Date(scheduler.startAt); // 解析起始时间
+    this.options = { viewportWidth: options?.viewportWidth ?? 1280, viewportHeight: options?.viewportHeight ?? 720, zoom: options?.zoom ?? 1 }; // 合并默认选项
+    this.pixelsPerMinute = this.computePixelsPerMinute(scheduler.timeScale); // 计算缩放后的每分钟像素
+  } // 结束构造
+
+  private computePixelsPerMinute(scale: SchedulerTimeScale): number { // 内部方法：根据刻度计算像素比例
+    const base = 2; // 定义基础像素密度
+    if (scale === 'hours') { // 若以小时为刻度
+      return base * this.options.zoom / 60; // 小时时间需要除以 60 得到每分钟像素
+    } // 条件结束
+    return base * this.options.zoom; // 默认分钟刻度直接乘缩放
+  } // 方法结束
+
+  public updateOptions(next: Partial<GanttLayoutOptions>): void { // 更新布局参数
+    this.options = { ...this.options, ...next }; // 合并新的配置
+    this.pixelsPerMinute = this.computePixelsPerMinute(this.scheduler.timeScale); // 重新计算缩放比例
+  } // 方法结束
+
+  public timeToX(time: string | Date): number { // 将时间转换成 x 坐标
+    const date = typeof time === 'string' ? new Date(time) : time; // 确保得到 Date 对象
+    const minutes = (date.getTime() - this.startAt.getTime()) / 60000; // 计算相对分钟差
+    return minutes * this.pixelsPerMinute; // 按比例转换为像素
+  } // 方法结束
+
+  public xToTime(x: number): Date { // 将 x 坐标转换回时间
+    const minutes = x / this.pixelsPerMinute; // 计算分钟差
+    return new Date(this.startAt.getTime() + minutes * 60000); // 叠加到起始时间得到日期
+  } // 方法结束
+
+  public rowToY(rowId: string): number { // 根据行标识计算 y 坐标
+    const index = this.scheduler.rows.findIndex((row) => row.id === rowId); // 寻找行索引
+    if (index === -1) { // 如果找不到行
+      throw new Error(`Unknown rowId: ${rowId}`); // 抛出错误提示
+    } // 条件结束
+    const rowHeight = this.styles.rowHeight + this.styles.rowGap; // 计算单行占据的高度
+    return this.styles.timelineHeight + index * rowHeight; // 返回时间轴下方的 y 坐标
+  } // 方法结束
+
+  public compute(): LayoutResult { // 主方法：执行布局计算
+    const rowPositions = new Map<string, number>(); // 准备行到 y 坐标的映射
+    this.scheduler.rows.forEach((row) => { // 遍历行
+      rowPositions.set(row.id, this.rowToY(row.id)); // 为每行记录 y 坐标
+    }); // 结束遍历
+
+    const tasks: LayoutTask[] = this.scheduler.tasks.map((task) => { // 遍历任务并生成布局对象
+      const rowIndex = this.scheduler.rows.findIndex((row) => row.id === task.rowId); // 查找任务所属行索引
+      const x = this.timeToX(task.start); // 计算起始 x
+      const durationMinutes = this.extractDuration(task); // 抽取任务持续时间
+      const width = Math.max(durationMinutes * this.pixelsPerMinute, this.styles.taskBarHeight); // 计算任务条宽度并做最小值限制
+      const y = rowPositions.get(task.rowId) ?? this.styles.timelineHeight; // 读取行的 y 坐标
+      return { task, x, y, width, height: this.styles.taskBarHeight, rowIndex }; // 返回布局结果
+    }); // 结束映射
+
+    const ticks = this.computeTicks(); // 计算时间刻度
+
+    return { tasks, ticks, rowPositions }; // 返回整体布局
+  } // 方法结束
+
+  private extractDuration(task: SchedulerTask): number { // 内部方法：提取任务持续时间
+    if (this.scheduler.timeScale === 'hours') { // 如果排程使用小时刻度
+      const hours = task.durationHr ?? (task.durationMin ? task.durationMin / 60 : 1); // 优先使用小时字段
+      return hours * 60; // 转换为分钟
+    } // 条件结束
+    return task.durationMin ?? (task.durationHr ? task.durationHr * 60 : 30); // 默认以分钟字段为主
+  } // 方法结束
+
+  private computeTicks(): LayoutTick[] { // 内部方法：计算时间刻度集合
+    const ticks: LayoutTick[] = []; // 初始化数组
+    const totalWidth = Math.max(this.options.viewportWidth, this.scheduler.tasks.reduce((max, task) => { // 计算任务覆盖的最大宽度
+      const endX = this.timeToX(task.start) + this.extractDuration(task) * this.pixelsPerMinute; // 计算任务结束的 x 坐标
+      return Math.max(max, endX); // 更新最大值
+    }, 0)); // reduce 结束
+
+    const majorGap = this.styles.tickMajor; // 读取主刻度间隔
+    for (let x = 0; x <= totalWidth + majorGap; x += this.styles.tickMinor) { // 以小刻度遍历到末尾
+      const time = this.xToTime(x); // 将坐标转换为时间
+      const label = this.formatTickLabel(time); // 生成标签
+      const major = x % majorGap === 0; // 判断是否为主刻度
+      ticks.push({ x, label, major }); // 存入刻度数组
+    } // 循环结束
+    return ticks; // 返回刻度集合
+  } // 方法结束
+
+  private formatTickLabel(time: Date): string { // 内部方法：格式化刻度标签
+    if (this.scheduler.timeScale === 'hours') { // 若以小时刻度显示
+      return time.toISOString().slice(11, 16); // 只取小时与分钟
+    } // 条件结束
+    return time.toISOString().slice(11, 16); // 分钟刻度同样取时分
+  } // 方法结束
+
+  public detectOverlap(rowId: string, taskId: string): boolean { // 检测同一行任务是否重叠
+    const target = this.scheduler.tasks.find((task) => task.id === taskId); // 查找目标任务
+    if (!target) { // 如果未找到
+      return false; // 返回不重叠
+    } // 条件结束
+    const targetStart = this.timeToX(target.start); // 目标任务起点 x
+    const targetEnd = targetStart + this.extractDuration(target) * this.pixelsPerMinute; // 目标任务结束 x
+    return this.scheduler.tasks.some((task) => { // 遍历所有任务
+      if (task.id === target.id || task.rowId !== rowId) { // 跳过自身或不同的行
+        return false; // 不构成重叠
+      } // 条件结束
+      const start = this.timeToX(task.start); // 计算其他任务起点
+      const end = start + this.extractDuration(task) * this.pixelsPerMinute; // 计算其他任务终点
+      return !(end <= targetStart || start >= targetEnd); // 判断时间区间是否相交
+    }); // 结束遍历
+  } // 方法结束
+} // 类结束

--- a/frontend/miniworld/src/scheduler/GanttRender.ts
+++ b/frontend/miniworld/src/scheduler/GanttRender.ts
@@ -1,0 +1,126 @@
+import Phaser from 'phaser'; // 引入 Phaser 用于绘制图形
+import { LayoutResult, LayoutTask } from './GanttLayout'; // 引入布局结果类型
+import { GANTT_STYLES } from './GanttStyles'; // 引入样式常量
+
+export class GanttRender { // 定义甘特图渲染类
+  private scene: Phaser.Scene; // 保存场景引用
+  private gridLayer: Phaser.GameObjects.Graphics; // 网格图层
+  private taskLayer: Phaser.GameObjects.Container; // 任务容器
+  private tickLayer: Phaser.GameObjects.Container; // 刻度文字容器
+  private dependencyLayer: Phaser.GameObjects.Graphics; // 依赖线图层
+
+  public constructor(scene: Phaser.Scene) { // 构造函数
+    this.scene = scene; // 保存场景
+    this.gridLayer = scene.add.graphics({ x: 0, y: 0 }); // 创建网格绘制层
+    this.taskLayer = scene.add.container(0, 0); // 创建任务容器
+    this.tickLayer = scene.add.container(0, 0); // 创建刻度文字容器
+    this.dependencyLayer = scene.add.graphics({ x: 0, y: 0 }); // 创建依赖线层
+    scene.cameras.main.setBackgroundColor(GANTT_STYLES.backgroundColor); // 设置背景颜色
+  } // 构造结束
+
+  public draw(layout: LayoutResult): void { // 主绘制入口
+    this.drawGrid(layout); // 绘制网格
+    this.drawTasks(layout.tasks); // 绘制任务条
+    this.drawDependencies(layout); // 绘制依赖线
+  } // 方法结束
+
+  private drawGrid(layout: LayoutResult): void { // 绘制网格背景
+    this.gridLayer.clear(); // 清空之前的图形
+    this.tickLayer.removeAll(true); // 清除旧刻度文本
+    this.gridLayer.lineStyle(1, GANTT_STYLES.gridColor, 0.35); // 设置线条样式
+    layout.ticks.forEach((tick) => { // 遍历刻度
+      this.gridLayer.beginPath(); // 开始路径
+      this.gridLayer.moveTo(tick.x, 0); // 移动到刻度顶端
+      this.gridLayer.lineTo(tick.x, this.scene.scale.height); // 画到视口底部
+      this.gridLayer.strokePath(); // 完成绘制
+      if (tick.major) { // 如果是主刻度
+        this.addTickLabel(tick.x, tick.label); // 绘制标签
+      } // 条件结束
+    }); // 遍历结束
+  } // 方法结束
+
+  private addTickLabel(x: number, label: string): void { // 在时间轴上添加文字
+    const text = this.scene.add.text(x + 4, 4, label, { fontSize: '12px', color: GANTT_STYLES.textColor }); // 创建文字对象
+    this.tickLayer.add(text); // 将文字放入刻度容器
+  } // 方法结束
+
+  private drawTasks(tasks: LayoutTask[]): void { // 绘制任务条
+    this.taskLayer.removeAll(true); // 清除旧的任务对象
+    tasks.forEach((entry) => { // 遍历任务布局
+      const color = this.resolveTaskColor(entry); // 计算任务颜色
+      const graphics = this.scene.add.graphics({ x: entry.x, y: entry.y }); // 创建图形对象
+      graphics.fillStyle(color, 1); // 设置填充颜色
+      graphics.fillRoundedRect(0, 0, entry.width, entry.height, 6); // 绘制圆角矩形
+      graphics.lineStyle(1, 0x000000, 0.25); // 添加边框线
+      graphics.strokeRoundedRect(0, 0, entry.width, entry.height, 6); // 绘制边框
+      this.taskLayer.add(graphics); // 将图形加入任务容器
+      const label = this.scene.add.text(entry.x + GANTT_STYLES.taskPadding, entry.y + GANTT_STYLES.taskPadding, entry.task.title, { fontSize: '14px', color: GANTT_STYLES.textColor }); // 添加任务标题
+      this.taskLayer.add(label); // 将文本加入容器
+      if (entry.task.progress !== undefined) { // 如果存在进度
+        this.drawProgress(entry); // 绘制进度条
+      } // 条件结束
+    }); // 结束遍历
+  } // 方法结束
+
+  private resolveTaskColor(entry: LayoutTask): number { // 根据任务状态返回颜色
+    switch (entry.task.status) { // 根据状态分支
+      case 'approved': // 如果是已审批
+        return GANTT_STYLES.approvedColor; // 返回审批颜色
+      case 'executing': // 如果在执行
+        return GANTT_STYLES.executingColor; // 返回执行颜色
+      case 'done': // 完成状态
+        return GANTT_STYLES.doneColor; // 返回完成颜色
+      case 'paused': // 暂停状态
+        return GANTT_STYLES.pausedColor; // 返回暂停颜色
+      case 'error': // 错误状态
+        return GANTT_STYLES.overdueColor; // 使用警告颜色
+      default: // 默认情况
+        return GANTT_STYLES.progressColor; // 使用计划颜色
+    } // 分支结束
+  } // 方法结束
+
+  private drawProgress(entry: LayoutTask): void { // 绘制执行进度
+    const percentage = Math.max(0, Math.min(1, (entry.task.progress ?? 0) / 100)); // 计算进度比例
+    const width = entry.width * percentage; // 计算进度条宽度
+    const bar = this.scene.add.graphics({ x: entry.x, y: entry.y + entry.height - 6 }); // 创建进度条图形
+    bar.fillStyle(GANTT_STYLES.selectionColor, 0.8); // 设置颜色
+    bar.fillRect(0, 0, width, 6); // 绘制矩形
+    this.taskLayer.add(bar); // 添加到任务容器
+  } // 方法结束
+
+  private drawDependencies(layout: LayoutResult): void { // 绘制依赖线
+    this.dependencyLayer.clear(); // 清空旧的依赖
+    this.dependencyLayer.lineStyle(GANTT_STYLES.dependencyStroke, GANTT_STYLES.dependencyColor, 1); // 设置线条样式
+    layout.tasks.forEach((entry) => { // 遍历任务
+      entry.task.dependsOn?.forEach((parentId) => { // 遍历依赖父任务
+        const parent = layout.tasks.find((item) => item.task.id === parentId); // 查找父任务布局
+        if (!parent) { // 如果没有找到
+          return; // 跳过绘制
+        } // 条件结束
+        this.dependencyLayer.beginPath(); // 开始绘制
+        const startX = parent.x + parent.width; // 计算依赖起点 x
+        const startY = parent.y + parent.height / 2; // 计算依赖起点 y
+        const endX = entry.x; // 依赖终点 x
+        const endY = entry.y + entry.height / 2; // 依赖终点 y
+        const midX = (startX + endX) / 2; // 计算中间折线位置
+        this.dependencyLayer.moveTo(startX, startY); // 移动到起点
+        this.dependencyLayer.lineTo(midX, startY); // 水平线到中间
+        this.dependencyLayer.lineTo(midX, endY); // 垂直线到终点 y
+        this.dependencyLayer.lineTo(endX, endY); // 水平线到终点
+        this.dependencyLayer.strokePath(); // 完成折线
+        this.drawArrow(endX, endY); // 在末端绘制箭头
+      }); // 结束依赖遍历
+    }); // 结束任务遍历
+  } // 方法结束
+
+  private drawArrow(x: number, y: number): void { // 绘制箭头小三角
+    const size = 6; // 箭头尺寸
+    this.dependencyLayer.fillStyle(GANTT_STYLES.dependencyColor, 1); // 设置填充颜色
+    this.dependencyLayer.beginPath(); // 开始路径
+    this.dependencyLayer.moveTo(x, y); // 移动到箭头尖端
+    this.dependencyLayer.lineTo(x - size, y - size / 2); // 绘制一侧
+    this.dependencyLayer.lineTo(x - size, y + size / 2); // 绘制另一侧
+    this.dependencyLayer.closePath(); // 闭合路径
+    this.dependencyLayer.fillPath(); // 填充三角形
+  } // 方法结束
+} // 类结束

--- a/frontend/miniworld/src/scheduler/GanttScene.ts
+++ b/frontend/miniworld/src/scheduler/GanttScene.ts
@@ -1,0 +1,79 @@
+import Phaser from 'phaser'; // 引入 Phaser 场景基类
+import { AgentAPI } from '../build/AgentAPI'; // 引入 AgentAPI 以便推送任务
+import { WorkCalendar } from '../time/WorkCalendar'; // 引入工作日历
+import { SchedulerIO } from '../config/SchedulerIO'; // 引入排程存储
+import { GanttLayout } from './GanttLayout'; // 引入布局计算
+import { GanttRender } from './GanttRender'; // 引入渲染器
+import { GanttInteraction } from './GanttInteraction'; // 引入交互控制器
+import { GanttDataBridge } from './GanttDataBridge'; // 引入数据桥
+import { SchedulerToolbar } from '../ui/tools/SchedulerToolbar'; // 引入工具栏
+import { HotReloadBus } from '../runtime/HotReloadBus'; // 引入热重载总线
+
+export default class GanttScene extends Phaser.Scene { // 定义甘特场景
+  private io!: SchedulerIO; // 存储排程 IO
+  private layout!: GanttLayout; // 存储布局计算器
+  private renderLayer!: GanttRender; // 存储渲染器
+  private interaction!: GanttInteraction; // 存储交互控制器
+  private bridge!: GanttDataBridge; // 存储数据桥
+  private toolbar!: SchedulerToolbar; // 存储工具栏控制
+  private calendar!: WorkCalendar; // 存储工作日历
+
+  public constructor() { // 构造函数
+    super('Gantt'); // 指定场景键名
+  } // 构造结束
+
+  public create(): void { // 场景创建入口
+    this.io = new SchedulerIO(); // 初始化排程 IO
+    this.renderLayer = new GanttRender(this); // 创建渲染器
+    void this.bootstrap(); // 异步加载排程
+  } // 方法结束
+
+  private async bootstrap(): Promise<void> { // 异步初始化逻辑
+    const scheduler = await this.io.load(); // 读取排程文件
+    this.layout = new GanttLayout(scheduler, { viewportWidth: this.scale.width, viewportHeight: this.scale.height, zoom: 1 }); // 创建布局
+    this.renderLayer.draw(this.layout.compute()); // 绘制初始视图
+    this.calendar = new WorkCalendar({}); // 创建工作日历
+    this.interaction = new GanttInteraction(scheduler, this.layout, this.calendar, this.io); // 创建交互控制器
+    this.bridge = new GanttDataBridge(new AgentAPI(), this.io); // 创建数据桥
+    this.bridge.setScheduler(scheduler); // 注入排程数据
+    this.toolbar = new SchedulerToolbar(this.io, this.bridge, this.interaction); // 创建工具栏控制
+    this.registerShortcuts(); // 注册快捷键
+    HotReloadBus.on('rulesChanged', () => this.handlePolicyRefresh()); // 监听规则变更事件
+    HotReloadBus.on('schedulerChanged', () => void this.reloadScheduler()); // 监听排程文件变更
+  } // 方法结束
+
+  private registerShortcuts(): void { // 注册键盘快捷键
+    const keyboard = this.input.keyboard; // 获取键盘输入
+    if (!keyboard) { // 如果不存在
+      return; // 直接返回
+    } // 条件结束
+    keyboard.on('keydown-S', (event: KeyboardEvent) => { // 监听 S 键
+      if (event.ctrlKey) { // 若按下 Ctrl
+        event.preventDefault(); // 阻止默认行为
+        void this.toolbar.triggerSave(); // 调用保存
+      } // 条件结束
+    }); // 监听结束
+    keyboard.on('keydown-D', (event: KeyboardEvent) => { // 监听 D 键
+      if (event.ctrlKey) { // 若按下 Ctrl
+        event.preventDefault(); // 阻止默认
+        this.interaction.duplicateSelected(); // 调用复制
+      } // 条件结束
+    }); // 监听结束
+    keyboard.on('keydown-DELETE', () => { // 监听 Delete 键
+      this.interaction.selectTask(null); // 清除选中
+    }); // 监听结束
+  } // 方法结束
+
+  private handlePolicyRefresh(): void { // 处理策略文件刷新
+    const hint = this.add.text(12, 12, '规则已更新，检查排程', { fontSize: '14px', color: '#ffcc00' }); // 显示提示
+    this.time.delayedCall(2000, () => hint.destroy()); // 两秒后移除提示
+  } // 方法结束
+
+  private async reloadScheduler(): Promise<void> { // 重新加载排程文件
+    const scheduler = await this.io.load(); // 读取最新排程
+    this.layout = new GanttLayout(scheduler, { viewportWidth: this.scale.width, viewportHeight: this.scale.height, zoom: 1 }); // 重建布局
+    this.bridge.setScheduler(scheduler); // 更新数据桥
+    this.interaction = new GanttInteraction(scheduler, this.layout, this.calendar, this.io); // 重建交互控制器
+    this.renderLayer.draw(this.layout.compute()); // 重新绘制
+  } // 方法结束
+} // 类结束

--- a/frontend/miniworld/src/scheduler/GanttStyles.ts
+++ b/frontend/miniworld/src/scheduler/GanttStyles.ts
@@ -1,0 +1,23 @@
+export const GANTT_STYLES = { // 定义甘特图的样式常量集合
+  timelineHeight: 48, // 时间轴的高度
+  rowHeight: 56, // 每一行资源的高度
+  rowGap: 8, // 行与行之间的间距
+  taskBarHeight: 32, // 任务条的默认高度
+  taskPadding: 6, // 任务条内侧的留白
+  dependencyStroke: 2, // 依赖线的描边宽度
+  dependencyColor: 0x4a90e2, // 依赖线的颜色
+  gridColor: 0xe0e0e0, // 网格线的颜色
+  backgroundColor: 0x0b0b0f, // 场景背景颜色
+  textColor: '#f5f5f5', // 文本渲染的颜色
+  tickMinor: 20, // 小刻度间距（像素）
+  tickMajor: 100, // 大刻度间距（像素）
+  selectionColor: 0xffcc00, // 选择高亮颜色
+  progressColor: 0x66bb6a, // 进度条颜色
+  overdueColor: 0xef5350, // 超期标记颜色
+  approvedColor: 0x42a5f5, // 审批状态颜色
+  executingColor: 0xffb300, // 执行状态颜色
+  doneColor: 0x7cb342, // 完成状态颜色
+  pausedColor: 0x8d6e63, // 暂停状态颜色
+} as const; // 使用常量断言确保类型稳定
+
+export type GanttStyles = typeof GANTT_STYLES; // 导出样式类型方便其他模块引用

--- a/frontend/miniworld/src/time/WorkCalendar.ts
+++ b/frontend/miniworld/src/time/WorkCalendar.ts
@@ -144,4 +144,20 @@ export class WorkCalendar { // 定义工作日历类
     } // 条件结束
     return { allowed: true, enforcedSilent: requireSilent, deadlineAt: this.resolveDeadline(now, options.deadline) }; // 允许执行
   } // 方法结束
+
+  public alignToNextSlot(target: Date): Date { // 将时间对齐到下一个工作时段
+    const aligned = new Date(target.getTime()); // 复制目标时间以便修改
+    const minutes = aligned.getMinutes(); // 读取分钟数
+    const remainder = minutes % 30; // 计算与半小时的余数
+    if (remainder !== 0) { // 如果不是整半小时
+      aligned.setMinutes(minutes + (30 - remainder), 0, 0); // 向上取整到最近的半小时并清理秒
+    } else { // 否则已经对齐
+      aligned.setSeconds(0, 0); // 将秒和毫秒清零
+    } // 条件结束
+    if (!this.isWithinWorkHours(aligned) || this.isCurfew(aligned)) { // 如果仍不满足工作条件
+      const fallback = this.nextSlot(undefined, TimeSystem.addMinutes(aligned, 15), true); // 查找下一个可执行时间
+      return fallback ?? aligned; // 如果找到则返回，否则保持对齐时间
+    } // 条件结束
+    return aligned; // 返回对齐后的时间
+  } // 方法结束
 } // 类结束

--- a/frontend/miniworld/src/ui/tools/SchedulerToolbar.ts
+++ b/frontend/miniworld/src/ui/tools/SchedulerToolbar.ts
@@ -1,0 +1,54 @@
+import { SchedulerIO } from '../../config/SchedulerIO'; // 引入排程存储
+import { GanttDataBridge } from '../../scheduler/GanttDataBridge'; // 引入数据桥
+import { GanttInteraction } from '../../scheduler/GanttInteraction'; // 引入交互控制器
+
+export interface SchedulerToolbarEvents { // 定义工具栏事件映射
+  save: void; // 保存事件
+  rollback: void; // 回滚事件
+  validate: void; // 校验事件
+  send: void; // 送审事件
+} // 接口结束
+
+export class SchedulerToolbar { // 定义工具栏控制类
+  private listeners: Map<keyof SchedulerToolbarEvents, Set<() => void>> = new Map(); // 存储事件监听器
+  private io: SchedulerIO; // 存储 IO 工具
+  private bridge: GanttDataBridge; // 存储数据桥
+  private interaction: GanttInteraction; // 存储交互控制器
+
+  public constructor(io: SchedulerIO, bridge: GanttDataBridge, interaction: GanttInteraction) { // 构造函数
+    this.io = io; // 保存 IO 工具
+    this.bridge = bridge; // 保存数据桥
+    this.interaction = interaction; // 保存交互控制器
+  } // 构造结束
+
+  public on<K extends keyof SchedulerToolbarEvents>(event: K, listener: () => void): void { // 注册事件回调
+    const bucket = this.listeners.get(event) ?? new Set(); // 获取或创建监听集合
+    bucket.add(listener); // 添加监听函数
+    this.listeners.set(event, bucket); // 回写集合
+  } // 方法结束
+
+  public async triggerSave(): Promise<void> { // 触发保存动作
+    await this.interaction.save(); // 调用交互层保存
+    this.emit('save'); // 广播事件
+  } // 方法结束
+
+  public async triggerRollback(args: string[] = ['--latest']): Promise<void> { // 触发回滚动作
+    await this.io.runRollback(args); // 调用 IO 执行回滚
+    this.emit('rollback'); // 广播事件
+  } // 方法结束
+
+  public async triggerValidate(): Promise<void> { // 触发校验动作
+    await this.io.runValidate(); // 调用 IO 校验
+    this.emit('validate'); // 广播事件
+  } // 方法结束
+
+  public async triggerSend(): Promise<void> { // 触发送审动作
+    await this.bridge.sendForApproval(); // 调用数据桥推送任务
+    this.emit('send'); // 广播事件
+  } // 方法结束
+
+  private emit(event: keyof SchedulerToolbarEvents): void { // 内部广播工具
+    const bucket = this.listeners.get(event); // 获取监听集合
+    bucket?.forEach((listener) => listener()); // 遍历执行
+  } // 方法结束
+} // 类结束

--- a/frontend/miniworld/test/scheduler/gantt_interaction.spec.ts
+++ b/frontend/miniworld/test/scheduler/gantt_interaction.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest'; // 引入测试工具
+import { WorkCalendar } from '../../src/time/WorkCalendar'; // 引入工作日历
+import { GanttLayout, SchedulerData } from '../../src/scheduler/GanttLayout'; // 引入布局类型
+import { GanttInteraction } from '../../src/scheduler/GanttInteraction'; // 引入交互控制器
+import type { SchedulerIO } from '../../src/config/SchedulerIO'; // 引入 IO 类型
+
+const scheduler: SchedulerData = { // 定义测试排程
+  version: 1, // 版本号
+  timeScale: 'minutes', // 时间刻度
+  startAt: '2025-10-11T08:00:00Z', // 起始时间
+  rows: [{ id: 'worker-1', label: '工人#1' }], // 定义资源行
+  tasks: [ // 定义任务
+    { id: 'task-1', type: 'build', title: '建造A', rowId: 'worker-1', start: '2025-10-11T08:00:00Z', durationMin: 30 }, // 初始任务
+  ], // 任务列表结束
+}; // 排程结束
+
+describe('GanttInteraction', () => { // 描述测试套件
+  const io = { save: vi.fn().mockResolvedValue(undefined) } as unknown as SchedulerIO; // 创建保存的假对象
+  const layout = new GanttLayout(scheduler); // 创建布局实例
+  const calendar = new WorkCalendar({ workHours: '08:00-18:00' }); // 创建工作日历
+  const interaction = new GanttInteraction(scheduler, layout, calendar, io); // 创建交互控制器
+
+  it('拖拽会吸附到半小时', () => { // 定义拖拽测试
+    interaction.dragTask('task-1', 20); // 向后拖拽20分钟
+    const updated = scheduler.tasks[0].start; // 读取更新后的开始
+    expect(updated).toBe('2025-10-11T08:30:00.000Z'); // 期望吸附到08:30
+  }); // 测试结束
+
+  it('调整持续时间会更新字段', () => { // 定义持续时间测试
+    interaction.resizeTask('task-1', 30); // 增加30分钟
+    expect(scheduler.tasks[0].durationMin).toBe(60); // 期望变为60分钟
+  }); // 测试结束
+
+  it('连接与断开依赖', () => { // 定义依赖测试
+    scheduler.tasks.push({ id: 'task-2', type: 'build', title: '建造B', rowId: 'worker-1', start: '2025-10-11T09:00:00Z', durationMin: 30 }); // 添加第二任务
+    interaction.connectDependency('task-1', 'task-2'); // 建立依赖
+    expect(scheduler.tasks[1].dependsOn).toEqual(['task-1']); // 期望依赖成立
+    interaction.disconnectDependency('task-1', 'task-2'); // 移除依赖
+    expect(scheduler.tasks[1].dependsOn).toBeUndefined(); // 期望依赖被移除
+  }); // 测试结束
+
+  it('保存会调用 IO', async () => { // 定义保存测试
+    await interaction.save(); // 调用保存
+    expect(io.save).toHaveBeenCalled(); // 期望触发保存
+  }); // 测试结束
+}); // 套件结束

--- a/frontend/miniworld/test/scheduler/gantt_layout.spec.ts
+++ b/frontend/miniworld/test/scheduler/gantt_layout.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'; // 引入测试框架
+import { GanttLayout, SchedulerData } from '../../src/scheduler/GanttLayout'; // 引入甘特布局
+
+const scheduler: SchedulerData = { // 定义测试用排程
+  version: 1, // 指定版本
+  timeScale: 'minutes', // 指定分钟刻度
+  startAt: '2025-10-11T08:00:00Z', // 定义起始时间
+  rows: [ // 定义资源行
+    { id: 'worker-1', label: '工人#1' }, // 第一行
+    { id: 'worker-2', label: '工人#2' }, // 第二行
+  ], // 行结束
+  tasks: [ // 定义任务数组
+    { id: 'task-1', type: 'build', title: '建造A', rowId: 'worker-1', start: '2025-10-11T08:30:00Z', durationMin: 60 }, // 第一任务
+    { id: 'task-2', type: 'build', title: '建造B', rowId: 'worker-1', start: '2025-10-11T09:15:00Z', durationMin: 30 }, // 第二任务（与任务一重叠）
+    { id: 'task-3', type: 'build', title: '建造C', rowId: 'worker-2', start: '2025-10-11T09:00:00Z', durationMin: 45 }, // 第三任务
+  ], // 任务结束
+}; // 排程结束
+
+describe('GanttLayout', () => { // 描述测试套件
+  it('timeToX 与 xToTime 互逆', () => { // 定义互逆测试
+    const layout = new GanttLayout(scheduler); // 创建布局实例
+    const time = '2025-10-11T10:00:00Z'; // 目标时间
+    const x = layout.timeToX(time); // 转换为坐标
+    const roundTrip = layout.xToTime(x).toISOString(); // 再转换回时间
+    expect(roundTrip).toBe(new Date(time).toISOString()); // 断言互逆
+  }); // 测试结束
+
+  it('缩放后坐标变化', () => { // 定义缩放测试
+    const layout = new GanttLayout(scheduler, { zoom: 1 }); // 创建默认缩放布局
+    const baseX = layout.timeToX('2025-10-11T08:30:00Z'); // 计算初始坐标
+    layout.updateOptions({ zoom: 2 }); // 更新缩放
+    const zoomedX = layout.timeToX('2025-10-11T08:30:00Z'); // 重新计算坐标
+    expect(zoomedX).toBeGreaterThan(baseX); // 期望缩放后坐标变大
+  }); // 测试结束
+
+  it('同一行检测重叠', () => { // 定义重叠测试
+    const layout = new GanttLayout(scheduler); // 创建布局实例
+    const overlaps = layout.detectOverlap('worker-1', 'task-2'); // 检查重叠
+    expect(overlaps).toBe(true); // 期望发现重叠
+    const separate = layout.detectOverlap('worker-2', 'task-3'); // 检查另一行
+    expect(separate).toBe(false); // 期望无重叠
+  }); // 测试结束
+}); // 套件结束

--- a/frontend/miniworld/test/scheduler/scheduler_io.spec.ts
+++ b/frontend/miniworld/test/scheduler/scheduler_io.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'; // 引入测试工具
+import { promises as fs } from 'fs'; // 引入文件操作
+import os from 'os'; // 引入临时目录工具
+import path from 'path'; // 引入路径工具
+import { SchedulerIO } from '../../src/config/SchedulerIO'; // 引入待测模块
+import { execFile } from 'child_process'; // 引入被 mock 的函数
+
+vi.mock('child_process', () => ({ // 预先 mock 子进程模块
+  execFile: vi.fn((cmd: string, args: string[], callback: (error: Error | null, stdout: string, stderr: string) => void) => { // 创建假的 execFile
+    callback(null, '', ''); // 立即调用回调模拟成功
+  }), // 函数结束
+})); // mock 结束
+
+const schedulerSample = { // 定义排程样本
+  version: 1, // 版本号
+  timeScale: 'minutes', // 时间单位
+  startAt: '2025-10-11T08:00:00Z', // 起始时间
+  rows: [{ id: 'worker-1', label: '工人#1' }], // 行列表
+  tasks: [], // 任务列表
+}; // 样本结束
+
+const execMock = vi.mocked(execFile); // 获取被 mock 的函数引用
+
+beforeEach(() => { // 在每个测试前执行
+  execMock.mockClear(); // 清空调用记录
+}); // 钩子结束
+
+describe('SchedulerIO', () => { // 定义测试套件
+  it('可以读取与写入排程', async () => { // 定义读写测试
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'scheduler-')); // 创建临时目录
+    const baseDir = path.join(tmp, 'scheduler'); // 计算排程目录
+    await fs.mkdir(baseDir, { recursive: true }); // 创建目录
+    const filePath = path.join(baseDir, 'scheduler.json'); // 计算文件路径
+    await fs.writeFile(filePath, JSON.stringify(schedulerSample, null, 2)); // 写入样本文件
+    const io = new SchedulerIO(baseDir, 'scheduler.json'); // 创建 IO 实例
+    const loaded = await io.load(); // 读取排程
+    expect(loaded).toEqual(schedulerSample); // 断言读取正确
+    await io.save(loaded); // 保存排程
+    const updated = JSON.parse(await fs.readFile(filePath, 'utf8')); // 重新读取文件
+    expect(updated).toEqual(schedulerSample); // 断言保存成功
+    expect(execMock).toHaveBeenCalledWith('python3', ['scripts/validate_scheduler.py'], expect.any(Function)); // 断言调用校验脚本
+    expect(execMock).toHaveBeenCalledWith('python3', ['scripts/snapshot_scheduler.py'], expect.any(Function)); // 断言调用快照脚本
+  }); // 测试结束
+
+  it('拒绝越界路径', () => { // 定义路径测试
+    expect(() => new SchedulerIO('/tmp', '../hack')).toThrow(); // 期望抛出错误
+  }); // 测试结束
+}); // 套件结束

--- a/scripts/rollback_scheduler.py
+++ b/scripts/rollback_scheduler.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""从快照目录回滚 scheduler.json（仅文本操作）。"""
+import argparse  # 引入命令行解析
+import pathlib  # 引入路径工具
+import shutil  # 引入文件复制
+import sys  # 引入系统模块
+
+BASE = pathlib.Path(__file__).resolve().parents[1]  # 计算仓库根目录
+SOURCE = BASE / 'assets' / 'scheduler' / 'scheduler.json'  # 主排程文件路径
+SNAP_DIR = BASE / 'assets' / 'scheduler' / 'snapshots'  # 快照目录路径
+
+parser = argparse.ArgumentParser(description='回滚 scheduler.json')  # 创建解析器
+parser.add_argument('--latest', action='store_true', help='回滚到最新快照')  # 添加最新选项
+parser.add_argument('--stamp', type=str, help='指定时间戳前缀')  # 添加指定时间戳选项
+args = parser.parse_args()  # 解析参数
+
+if not SNAP_DIR.exists():  # 如果快照目录不存在
+    print('无快照可用', file=sys.stderr)  # 输出提示
+    sys.exit(1)  # 返回错误
+
+candidates = sorted(SNAP_DIR.glob('*_scheduler.json'))  # 收集所有快照
+if not candidates:  # 如果没有快照
+    print('快照目录为空', file=sys.stderr)  # 输出提示
+    sys.exit(1)  # 返回错误
+
+selected = None  # 初始化选择结果
+if args.latest:  # 如果选择最新
+    selected = candidates[-1]  # 取最后一个
+elif args.stamp:  # 如果指定时间戳
+    prefix = f"{args.stamp}_scheduler.json"  # 构造文件名
+    for item in candidates:  # 遍历快照
+        if item.name == prefix:  # 如果名称匹配
+            selected = item  # 记录匹配项
+            break  # 终止循环
+else:  # 未指定选项
+    parser.error('必须提供 --latest 或 --stamp')  # 抛出错误
+
+if not selected:  # 如果仍未找到快照
+    print('未找到匹配快照', file=sys.stderr)  # 输出提示
+    sys.exit(1)  # 返回错误
+
+shutil.copyfile(selected, SOURCE)  # 复制快照到主文件
+print(f'已回滚到: {selected}')  # 输出结果

--- a/scripts/snapshot_scheduler.py
+++ b/scripts/snapshot_scheduler.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""生成 scheduler.json 的时间戳快照（仅文本复制）。"""
+import datetime  # 引入日期时间模块
+import pathlib  # 引入路径工具
+import shutil  # 引入文件复制工具
+import sys  # 引入系统模块
+
+BASE = pathlib.Path(__file__).resolve().parents[1]  # 计算仓库根目录
+SOURCE = BASE / 'assets' / 'scheduler' / 'scheduler.json'  # 构造源文件路径
+TARGET_DIR = BASE / 'assets' / 'scheduler' / 'snapshots'  # 构造快照目录路径
+
+if not SOURCE.exists():  # 如果源文件不存在
+    print('scheduler.json 不存在，无法生成快照', file=sys.stderr)  # 输出错误提示
+    sys.exit(1)  # 返回错误码
+
+TARGET_DIR.mkdir(parents=True, exist_ok=True)  # 确保快照目录存在
+stamp = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H-%M-%SZ')  # 生成UTC时间戳
+TARGET = TARGET_DIR / f'{stamp}_scheduler.json'  # 生成目标文件路径
+shutil.copyfile(SOURCE, TARGET)  # 复制文件内容
+print(f'生成快照: {TARGET}')  # 输出结果

--- a/scripts/validate_scheduler.py
+++ b/scripts/validate_scheduler.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""校验 scheduler.json：依赖环、时间冲突、资源冲突。"""
+import datetime  # 引入日期时间模块
+import json  # 引入JSON解析
+import pathlib  # 引入路径工具
+import sys  # 引入系统模块
+from typing import Dict, List, Set  # 引入类型注解
+
+BASE = pathlib.Path(__file__).resolve().parents[1]  # 计算仓库根目录
+SCHED_PATH = BASE / 'assets' / 'scheduler' / 'scheduler.json'  # 排程文件路径
+POLICY_PATH = BASE / 'assets' / 'agents' / 'policies.json'  # 策略文件路径
+
+if not SCHED_PATH.exists():  # 如果排程文件缺失
+    print('缺少 scheduler.json', file=sys.stderr)  # 输出错误
+    sys.exit(1)  # 返回错误码
+
+scheduler = json.loads(SCHED_PATH.read_text(encoding='utf-8'))  # 读取排程
+policies = json.loads(POLICY_PATH.read_text(encoding='utf-8')) if POLICY_PATH.exists() else {}  # 读取策略
+
+errors: List[str] = []  # 存放错误列表
+
+# 依赖环检测
+edges: Dict[str, List[str]] = {}  # 构造依赖图
+for task in scheduler.get('tasks', []):  # 遍历任务
+    edges[task['id']] = task.get('dependsOn', [])  # 记录依赖列表
+
+visiting: Set[str] = set()  # DFS中的访问栈
+visited: Set[str] = set()  # 已访问集合
+
+def dfs(node: str) -> bool:  # 定义深度优先检测函数
+    if node in visiting:  # 如果节点在栈中
+        return True  # 检测到环
+    if node in visited:  # 如果已经检查过
+        return False  # 无需重复
+    visiting.add(node)  # 标记节点在访问栈中
+    for dep in edges.get(node, []):  # 遍历依赖
+        if dfs(dep):  # 递归检测
+            return True  # 传播环信息
+    visiting.remove(node)  # 移除访问栈标记
+    visited.add(node)  # 标记为已访问
+    return False  # 未发现环
+
+for task_id in edges:  # 遍历所有节点
+    if dfs(task_id):  # 如果检测到环
+        errors.append(f'依赖环: {task_id}')  # 记录错误
+        break  # 发现环即可停止
+
+# 时间冲突检测
+work_hours = policies.get('workHours', '00:00-23:59')  # 读取工作时段
+curfew = policies.get('curfew')  # 读取宵禁
+holidays = set(policies.get('holiday', []))  # 读取假日列表
+
+work_start, work_end = work_hours.split('-')  # 拆分工作时段
+work_start_minutes = int(work_start[:2]) * 60 + int(work_start[3:5])  # 转换为分钟
+work_end_minutes = int(work_end[:2]) * 60 + int(work_end[3:5])  # 转换为分钟
+
+curfew_start = curfew.split('-')[0] if curfew else None  # 获取宵禁开始
+curfew_end = curfew.split('-')[1] if curfew else None  # 获取宵禁结束
+curfew_start_min = int(curfew_start[:2]) * 60 + int(curfew_start[3:5]) if curfew_start else None  # 宵禁开始分钟
+curfew_end_min = int(curfew_end[:2]) * 60 + int(curfew_end[3:5]) if curfew_end else None  # 宵禁结束分钟
+
+def in_curfew(minute: int) -> bool:  # 判断分钟是否处于宵禁
+    if curfew_start_min is None and curfew_end_min is None:  # 如果未配置
+        return False  # 不受限制
+    if curfew_start_min is not None and curfew_end_min is not None:  # 两端均存在
+        if curfew_start_min <= curfew_end_min:  # 未跨日
+            return curfew_start_min <= minute < curfew_end_min  # 判断区间
+        return minute >= curfew_start_min or minute < curfew_end_min  # 跨日判断
+    if curfew_start_min is not None:  # 仅有开始
+        return minute >= curfew_start_min  # 判断是否晚于开始
+    if curfew_end_min is not None:  # 仅有结束
+        return minute < curfew_end_min  # 判断是否早于结束
+    return False  # 默认不在宵禁
+
+for task in scheduler.get('tasks', []):  # 遍历任务
+    start = datetime.datetime.fromisoformat(task['start'].replace('Z', '+00:00'))  # 解析开始时间
+    duration = task.get('durationMin') or (task.get('durationHr', 0) * 60)  # 获取持续时间
+    end = start + datetime.timedelta(minutes=duration)  # 计算结束时间
+    if start.date().isoformat() in holidays:  # 如果处于假日
+        errors.append(f"假日冲突: {task['id']}")  # 记录错误
+        continue  # 跳过后续判断
+    start_minute = start.hour * 60 + start.minute  # 计算开始分钟
+    end_minute = end.hour * 60 + end.minute  # 计算结束分钟
+    if start_minute < work_start_minutes or end_minute > work_end_minutes:  # 判断是否超出工作时段
+        errors.append(f"工作时间冲突: {task['id']}")  # 记录错误
+    if in_curfew(start_minute) or in_curfew(end_minute % (24 * 60)):  # 判断是否触发宵禁
+        errors.append(f"宵禁冲突: {task['id']}")  # 记录错误
+
+# 资源冲突检测
+rows: Dict[str, List[tuple]] = {}  # 记录每个行的任务区间
+for task in scheduler.get('tasks', []):  # 遍历任务
+    start = datetime.datetime.fromisoformat(task['start'].replace('Z', '+00:00'))  # 解析开始
+    duration = task.get('durationMin') or (task.get('durationHr', 0) * 60)  # 获取持续时间
+    end = start + datetime.timedelta(minutes=duration)  # 计算结束
+    rows.setdefault(task['rowId'], []).append((start, end, task['id']))  # 按行保存
+
+for row_id, intervals in rows.items():  # 遍历每个资源行
+    intervals.sort(key=lambda item: item[0])  # 按开始时间排序
+    for i in range(1, len(intervals)):  # 遍历相邻区间
+        prev_end = intervals[i - 1][1]  # 前一个结束时间
+        current_start = intervals[i][0]  # 当前开始时间
+        if current_start < prev_end:  # 如果重叠
+            errors.append(f"资源冲突: {row_id} -> {intervals[i - 1][2]} 与 {intervals[i][2]}")  # 记录冲突
+
+if errors:  # 如果存在错误
+    print('排程校验失败:')  # 输出标题
+    for issue in errors:  # 遍历错误
+        print(f'- {issue}')  # 输出错误详情
+    sys.exit(1)  # 返回错误码
+
+print('排程校验通过')  # 如果无错误则输出成功


### PR DESCRIPTION
## Summary
- add Phaser-based GanttScene with layout, rendering, interaction, and data bridge modules
- implement scheduler I/O utilities, toolbar controller, and supporting scripts for snapshot, rollback, and validation
- document workflow and provide Vitest coverage for layout math, interaction behavior, and I/O safeguards

## Testing
- pnpm --filter miniworld test

------
https://chatgpt.com/codex/tasks/task_e_68ea522aef6883289c53ea908fe88a19